### PR TITLE
Add new 'kind' test for Jinja and modify templates accordingly

### DIFF
--- a/pyecoregen/ecore.py
+++ b/pyecoregen/ecore.py
@@ -109,7 +109,14 @@ class EcoreGenerator(multigen.jinja.JinjaGenerator):
 
     @staticmethod
     def test_type(value, type_):
-        """Jinja test to check object type."""
+        """Jinja test to check if an object's class is exactly the tested type."""
+        return value.__class__ is type_
+
+    @staticmethod
+    def test_kind(value, type_):
+        """Jinja test to check the 'kind' or an object.
+        An object is 'kind' of a type when the object's class isinstance from the tested type.
+        """
         return isinstance(value, type_)
 
     @staticmethod
@@ -208,6 +215,7 @@ class EcoreGenerator(multigen.jinja.JinjaGenerator):
         environment = super().create_environment(**kwargs)
         environment.tests.update({
             'type': self.test_type,
+            'kind': self.test_kind,
             'opposite_before_self': self.test_opposite_before_self,
         })
         environment.filters.update({

--- a/pyecoregen/templates/module.py.tpl
+++ b/pyecoregen/templates/module.py.tpl
@@ -136,10 +136,10 @@ class {{ c.name }}({{ c | supertypes }}):
 
 {#- -------------------------------------------------------------------------------------------- -#}
 
-{%- for c in element.eClassifiers if c is type(ecore.EEnum) %}
+{%- for c in element.eClassifiers if c is type(ecore.EEnum) -%}
 {{ generate_enum(c) }}
 {%- endfor %}
-{%- for c in element.eClassifiers if c is type(ecore.EDataType) and c is not type(ecore.EEnum)%}
+{% for c in element.eClassifiers if c is type(ecore.EDataType) -%}
 {{ generate_edatatype(c) }}
 {%- endfor %}
 

--- a/pyecoregen/templates/package.py.tpl
+++ b/pyecoregen/templates/package.py.tpl
@@ -46,7 +46,7 @@ eSuperPackage = {{ element.eSuperPackage.name | default('None') }}
     {%- endwith %}
 {%- endif %}
 
-otherClassifiers = [{{ element.eClassifiers | select('type', ecore.EDataType) | map(attribute='name') | join(', ') }}]
+otherClassifiers = [{{ element.eClassifiers | select('kind', ecore.EDataType) | map(attribute='name') | join(', ') }}]
 
 for classif in otherClassifiers:
     eClassifiers[classif.name] = classif


### PR DESCRIPTION
The introduction of the test 'kind' and the modification of the test 'type' tries to match the OCL semantic of 'oclIsKindOf' and 'oclIsTypeOf'. 

In this context, the differentiation is usefull for the generation of EDataType and EEnum. EEnum inherits from EDataType and, in some cases, the code is equivalent (so 'kind' can be used) while in other case, a strong difference is made in the generation (so 'type' is used).

I prefer to create a PR for this one as I'm totally new to Jinja, perhaps this is not the best solution.