### PR TITLE
pythonic names generation

### DIFF
--- a/pyecoregen/adapter.py
+++ b/pyecoregen/adapter.py
@@ -9,7 +9,7 @@ _logger = logging.getLogger(__name__)
 
 
 @contextlib.contextmanager
-def adapt_name():
+def pythonic_names():
     original_get_attribute = ecore.ENamedElement.__getattribute__
 
     def get_attribute(self, name):

--- a/pyecoregen/adapter.py
+++ b/pyecoregen/adapter.py
@@ -15,7 +15,7 @@ def pythonic_names():
     def get_attribute(self, name):
         value = original_get_attribute(self, name)
 
-        if name == '_ENamedElement__name':
+        if name == 'name':
             while keyword.iskeyword(value):
                 # appending underscores is a typical way of removing name clashes in Python:
                 value += '_'

--- a/pyecoregen/adapter.py
+++ b/pyecoregen/adapter.py
@@ -1,0 +1,27 @@
+"""In place model adaptation of properties to become Python code compatible."""
+import contextlib
+import keyword
+import logging
+
+from pyecore import ecore
+
+_logger = logging.getLogger(__name__)
+
+
+@contextlib.contextmanager
+def adapt_name():
+    original_get_attribute = ecore.ENamedElement.__getattribute__
+
+    def get_attribute(self, name):
+        value = original_get_attribute(self, name)
+
+        if name == '_ENamedElement__name':
+            while keyword.iskeyword(value):
+                # appending underscores is a typical way of removing name clashes in Python:
+                value += '_'
+
+        return value
+
+    ecore.ENamedElement.__getattribute__ = get_attribute
+    yield
+    ecore.ENamedElement.__getattribute__ = original_get_attribute

--- a/pyecoregen/ecore.py
+++ b/pyecoregen/ecore.py
@@ -6,6 +6,7 @@ import re
 import multigen.formatter
 import multigen.jinja
 from pyecore import ecore
+from pyecoregen.adapter import pythonic_names
 
 
 class EcoreTask(multigen.jinja.JinjaTask):
@@ -234,3 +235,7 @@ class EcoreGenerator(multigen.jinja.JinjaGenerator):
         environment.globals.update({'ecore': ecore})
 
         return environment
+
+    def generate(self, model, outfolder):
+        with pythonic_names():
+            super().generate(model, outfolder)

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -1,0 +1,30 @@
+from pyecore import ecore
+from pyecoregen.adapter import adapt_name
+
+
+def test__name_adapter():
+    p = ecore.EPackage('MyPackage')
+
+    c1 = ecore.EClass('MyClass')
+    p.eClassifiers.append(c1)
+    a1 = ecore.EAttribute('att', ecore.EString, upper=-1)
+    c1.eStructuralFeatures.append(a1)
+
+    c2 = ecore.EClass('pass')
+    p.eClassifiers.append(c2)
+    a2 = ecore.EAttribute('else', ecore.EString, upper=-1)
+    c2.eStructuralFeatures.append(a2)
+
+    assert c2.name == 'pass'
+    assert a2.name == 'else'
+
+    with adapt_name():
+        assert c1.name == 'MyClass'
+        assert a1.name == 'att'
+        assert c2.name == 'pass_'
+        assert a2.name == 'else_'
+
+    assert c2.name == 'pass'
+    assert a2.name == 'else'
+
+

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -1,8 +1,8 @@
 from pyecore import ecore
-from pyecoregen.adapter import adapt_name
+from pyecoregen.adapter import pythonic_names
 
 
-def test__name_adapter():
+def test__pythonic_names():
     p = ecore.EPackage('MyPackage')
 
     c1 = ecore.EClass('MyClass')
@@ -18,7 +18,7 @@ def test__name_adapter():
     assert c2.name == 'pass'
     assert a2.name == 'else'
 
-    with adapt_name():
+    with pythonic_names():
         assert c1.name == 'MyClass'
         assert a1.name == 'att'
         assert c2.name == 'pass_'

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -196,3 +196,24 @@ def test_class_with_feature_many(pygen_output_dir):
     assert generated_class is mm.MyClass
     assert isinstance(mm.MyClass.any, EAttribute)
     assert instance.any == set()
+
+
+def test_pythonic_names(pygen_output_dir):
+    rootpkg = EPackage('pythonic_names')
+
+    c1 = EClass('MyClass')
+    rootpkg.eClassifiers.append(c1)
+    a1 = EAttribute('att', EString, upper=-1)
+    c1.eStructuralFeatures.append(a1)
+
+    c2 = EClass('pass')
+    rootpkg.eClassifiers.append(c2)
+    a2 = EAttribute('else', EString, upper=-1)
+    c2.eStructuralFeatures.append(a2)
+
+    mm = generate_meta_model(rootpkg, pygen_output_dir)
+
+    assert mm.eClassifiers['MyClass'] is mm.MyClass
+    assert mm.eClassifiers['pass_'] is mm.pass_
+    assert isinstance(mm.pass_.else_, EAttribute)
+    assert mm.pass_().else_ == set()


### PR DESCRIPTION
In order to generate Pythonic identifiers, fixing #2, I added a corresponding context manager to new module ``adapter.py``. Please take a look.

One favor to ask: The used approach of temporarily changing ``ENamedElement.__getattribute__`` depends on the name of the internal ``__name`` property. Python tries to hide ``__name`` by applying a bit of name mangling, which I had to guess in the context manager implementation, checking the attribute name of `_ENamedElement__name``, which is documented by ugly. Would you mind changing the internal attribute to "protected" by using only a single leading underscore?

If you did, please adapt the looked up name to just be ``_name`` here as well, since I'll be offline for a while.