### PR TITLE
Add the ability to deal with remote ecore URI

### DIFF
--- a/pyecoregen/cli.py
+++ b/pyecoregen/cli.py
@@ -3,6 +3,7 @@ import argparse
 import collections
 import logging
 import sys
+import re
 
 import pyecore.resources
 from pyecoregen.ecore import EcoreGenerator
@@ -53,10 +54,19 @@ def configure_logging(parsed_args):
     )
 
 
+def select_uri_implementation(ecore_model_path):
+    """Select the right URI implementation regarding the Ecore model path schema."""
+    url_pattern = re.compile('^http(s)?://.*')
+    if url_pattern.match(ecore_model_path):
+        return pyecore.resources.resource.HttpURI
+    return pyecore.resources.URI
+
+
 def load_model(ecore_model_path):
     """Load a single Ecore model and return the root package."""
     rset = pyecore.resources.ResourceSet()
-    resource = rset.get_resource(pyecore.resources.URI(ecore_model_path))
+    uri_implementation = select_uri_implementation(ecore_model_path)
+    resource = rset.get_resource(uri_implementation(ecore_model_path))
     return resource.contents[0]
 
 

--- a/pyecoregen/cli.py
+++ b/pyecoregen/cli.py
@@ -9,6 +9,9 @@ import pyecore.resources
 from pyecoregen.ecore import EcoreGenerator
 
 
+URL_PATTERN = re.compile('^http(s)?://.*')
+
+
 def main():
     generate_from_cli(sys.argv[1:])  # nocover
 
@@ -56,8 +59,7 @@ def configure_logging(parsed_args):
 
 def select_uri_implementation(ecore_model_path):
     """Select the right URI implementation regarding the Ecore model path schema."""
-    url_pattern = re.compile('^http(s)?://.*')
-    if url_pattern.match(ecore_model_path):
+    if URL_PATTERN.match(ecore_model_path):
         return pyecore.resources.resource.HttpURI
     return pyecore.resources.URI
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,8 @@
 from unittest import mock
 
-import pyecore.ecore
-from pyecoregen.cli import generate_from_cli
+import pyecore
+import pytest
+from pyecoregen.cli import generate_from_cli, select_uri_implementation
 
 
 @mock.patch('pyecoregen.cli.EcoreGenerator')
@@ -19,3 +20,21 @@ def test__generate_from_cli(generator_mock, cwd_module_dir):
     assert isinstance(model, pyecore.ecore.EPackage)
     assert model.name == 'library'
     assert path == 'some/folder'
+
+
+testdata = [
+    ('/tmp/test.ecore', pyecore.resources.URI),
+    ('C:\\test.ecore', pyecore.resources.URI),
+    ('./test.ecore', pyecore.resources.URI),
+    ('test.ecore', pyecore.resources.URI),
+    ('http://test.com/myuri.ecore', pyecore.resources.resource.HttpURI),
+    ('http://test.com/myuri', pyecore.resources.resource.HttpURI),
+    ('https://test.com/myuri.ecore', pyecore.resources.resource.HttpURI),
+    ('https://test.com/mypath?path=uri.ecore', pyecore.resources.resource.HttpURI),
+]
+
+
+@pytest.mark.parametrize("path, implementation", testdata)
+def test__selected_uri(path, implementation):
+    uri = select_uri_implementation(path)
+    assert uri is implementation


### PR DESCRIPTION
This commit introduce a kind of switch that give the ability to fetch .ecore/.xmi files from a remote URI. This does not implies modifications to the pyecoregen CLI options. 

When a remote URI is discovered (i.e, that begins with `http(s)://`, the URI implementation is simply changed from `URI` to `HttpURI` from `pyecore.resources.resource`.