### PR TITLE
Fix bad indentation when EOperation documentation is used

### DIFF
--- a/pyecoregen/ecore.py
+++ b/pyecoregen/ecore.py
@@ -131,7 +131,7 @@ class EcoreGenerator(multigen.jinja.JinjaGenerator):
     def filter_docstringline(value: ecore.EModelElement) -> str:
         annotation = value.getEAnnotation('http://www.eclipse.org/emf/2002/GenModel')
         doc = annotation.details.get('documentation', '') if annotation else None
-        return '"""{}"""\n'.format(doc) if doc else ''
+        return '"""{}"""'.format(doc) if doc else ''
 
     @staticmethod
     def filter_supertypes(value: ecore.EClass):

--- a/pyecoregen/templates/module.py.tpl
+++ b/pyecoregen/templates/module.py.tpl
@@ -108,7 +108,7 @@ class {{ c.name }}({{ c | supertypes }}):
 
 {%- macro generate_operation(o) %}
     def {{ o.name }}(self{{ generate_operation_args(o) }}):
-        {{ o | docstringline -}}
+        {{ o | docstringline }}
         raise NotImplementedError('operation {{ o.name }}(...) not yet implemented')
 {%- endmacro %}
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -4,7 +4,7 @@ import importlib
 import pytest
 
 from pyecore.ecore import EPackage, EClass, EReference, EEnum, EAttribute, EInt, EOperation, \
-    EParameter, EString, EDataType
+    EParameter, EString, EDataType, EAnnotation
 from pyecoregen.ecore import EcoreGenerator
 
 
@@ -233,3 +233,21 @@ def test_attribute_with_feature_id(pygen_output_dir):
     assert isinstance(mm.MyClass.att2, EAttribute)
     assert mm.MyClass.att.iD is True
     assert mm.MyClass.att2.iD is False
+
+
+def test_eoperation_with_documentation(pygen_output_dir):
+    rootpkg = EPackage('eoperation_with_documentation')
+    c1 = EClass('MyClass')
+    rootpkg.eClassifiers.append(c1)
+
+    operation = EOperation('do_it')
+    doc = EAnnotation('http://www.eclipse.org/emf/2002/GenModel')
+    operation.eAnnotations.append(doc)
+    doc.details['documentation'] = 'This is a documentation test'
+    c1.eOperations.append(operation)
+
+    mm = generate_meta_model(rootpkg, pygen_output_dir)
+
+    instance = mm.MyClass()
+    with pytest.raises(NotImplementedError):
+        instance.do_it()


### PR DESCRIPTION
I was generating the UML metamodel using PyEcoregen, and everything generates fine except the `raise NotImplementedError(...)` statements. 

It turns out that  when documentation is inserted in an EOperation EAnnotation, the template 'resets' the indentation for the EOperation body. This result in a syntax error. 

This fix get rid of the extra space removal in the template and adds a new test to check this case.