### PR TITLE
Feature/derived changeable attribute

### DIFF
--- a/pyecoregen/templates/module.py.tpl
+++ b/pyecoregen/templates/module.py.tpl
@@ -54,9 +54,12 @@ class {{ c.name }}({{ c | supertypes }}):
     def {{ d.name }}(self):
         return self._{{ d.name }}
 
+    {%- if d.changeable %}
+
     @{{ d.name }}.setter
     def {{ d.name }}(self, value):
         self._{{ d.name }} = value
+    {% endif %}
 {%- endmacro %}
 
 {#- -------------------------------------------------------------------------------------------- -#}

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -266,3 +266,26 @@ def test_eoperation_with_documentation(pygen_output_dir):
     instance = mm.MyClass()
     with pytest.raises(NotImplementedError):
         instance.do_it()
+
+
+def test_eattribute_derived_not_changeable(pygen_output_dir):
+    rootpkg = EPackage('changeable_attribute')
+    c1 = EClass('MyClass')
+    rootpkg.eClassifiers.append(c1)
+
+    att1 = EAttribute('att1', EString, derived=True, changeable=True)
+    att2 = EAttribute('att2', EString, derived=True, changeable=False)
+
+    c1.eStructuralFeatures.extend([att2, att1])
+
+    mm = generate_meta_model(rootpkg, pygen_output_dir)
+
+    instance = mm.MyClass()
+    assert instance.att1 is None
+    assert instance.att2 is None
+
+    instance.att1 = "test_value"
+    assert instance.att1 == "test_value"
+
+    with pytest.raises(AttributeError):
+        instance.att2 = "test_value2"


### PR DESCRIPTION
This is just a small modification to manage not changeable derived `EAttribute`. I plan to start a new implementation/generate the UML metamodel and from the experimentations I've done, there were too many of them.
I will also add the same modification in the Acceleo generator, but I think pyecoregen should be the privileged generator.