### PR TITLE
Feature/package autoregistration

### DIFF
--- a/pyecoregen/cli.py
+++ b/pyecoregen/cli.py
@@ -32,6 +32,12 @@ def generate_from_cli(args):
         required=True
     )
     parser.add_argument(
+        '--auto-register-package',
+        '-a',
+        help="Generate package auto-registration for the PyEcore 'global_registry'.",
+        action='store_true'
+    )
+    parser.add_argument(
         '--verbose',
         '-v',
         help="Increase logging verbosity.",
@@ -42,7 +48,7 @@ def generate_from_cli(args):
 
     configure_logging(parsed_args)
     model = load_model(parsed_args.ecore_model)
-    EcoreGenerator().generate(model, parsed_args.out_folder)
+    EcoreGenerator().generate(model, parsed_args.out_folder, global_vars=vars(parsed_args))
 
 
 def configure_logging(parsed_args):

--- a/pyecoregen/cli.py
+++ b/pyecoregen/cli.py
@@ -33,7 +33,6 @@ def generate_from_cli(args):
     )
     parser.add_argument(
         '--auto-register-package',
-        '-a',
         help="Generate package auto-registration for the PyEcore 'global_registry'.",
         action='store_true'
     )
@@ -48,7 +47,7 @@ def generate_from_cli(args):
 
     configure_logging(parsed_args)
     model = load_model(parsed_args.ecore_model)
-    EcoreGenerator().generate(model, parsed_args.out_folder, global_vars=vars(parsed_args))
+    EcoreGenerator().generate(model, parsed_args.out_folder, auto_register_package=parsed_args.auto_register_package)
 
 
 def configure_logging(parsed_args):

--- a/pyecoregen/ecore.py
+++ b/pyecoregen/ecore.py
@@ -237,6 +237,8 @@ class EcoreGenerator(multigen.jinja.JinjaGenerator):
 
         return environment
 
-    def generate(self, model, outfolder):
+    def generate(self, model, outfolder, global_vars=None):
+        if global_vars:
+            self.environment.globals.update(global_vars)
         with pythonic_names():
             super().generate(model, outfolder)

--- a/pyecoregen/ecore.py
+++ b/pyecoregen/ecore.py
@@ -237,8 +237,7 @@ class EcoreGenerator(multigen.jinja.JinjaGenerator):
 
         return environment
 
-    def generate(self, model, outfolder, global_vars=None):
-        if global_vars:
-            self.environment.globals.update(global_vars)
+    def generate(self, model, outfolder, auto_register_package=False):
+        self.environment.globals.update({'auto_register_package': auto_register_package})
         with pythonic_names():
             super().generate(model, outfolder)

--- a/pyecoregen/templates/package.py.tpl
+++ b/pyecoregen/templates/package.py.tpl
@@ -61,7 +61,8 @@ for classif in eClassifiers.values():
 for subpack in eSubpackages:
     eClass.eSubpackages.append(subpack.eClass)
 {% if auto_register_package %}
-for pack in [{{ element.name }}, *eSubpackages]:
+register_packages = [{{ element.name }}] + eSubpackages
+for pack in register_packages:
     global_registry[pack.nsURI] = pack
 
 {% endif %}

--- a/pyecoregen/templates/package.py.tpl
+++ b/pyecoregen/templates/package.py.tpl
@@ -1,3 +1,6 @@
+{% if auto_register_package -%}
+    from pyecore.resources import global_registry
+{%- endif %}
 from .{{ element.name }} import getEClassifier, eClassifiers
 from .{{ element.name }} import name, nsURI, nsPrefix, eClass
 {% if element.eClassifiers -%}
@@ -57,3 +60,8 @@ for classif in eClassifiers.values():
 
 for subpack in eSubpackages:
     eClass.eSubpackages.append(subpack.eClass)
+{% if auto_register_package %}
+for pack in [{{ element.name }}, *eSubpackages]:
+    global_registry[pack.nsURI] = pack
+
+{% endif %}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,14 +16,10 @@ def test__generate_from_cli(generator_mock, cwd_module_dir):
     mock_generate = generator_mock().generate
     model = mock_generator.generate.call_args[0][0]
     path = mock_generator.generate.call_args[0][1]
-    global_vars = mock_generator.generate.call_args[1]['global_vars']
 
     assert isinstance(model, pyecore.ecore.EPackage)
     assert model.name == 'library'
     assert path == 'some/folder'
-    assert not global_vars['auto_register_package']
-    assert global_vars['out_folder'] == 'some/folder'
-    assert global_vars['ecore_model'] == 'input/library.ecore'
 
 
 @mock.patch('pyecoregen.cli.EcoreGenerator')
@@ -31,21 +27,17 @@ def test__generate_from_cli_autoregistration(generator_mock, cwd_module_dir):
     mock_generator = generator_mock()
     mock_generator.generate = mock.MagicMock()
 
-    generate_from_cli(['-e', 'input/library.ecore', '-o', 'some/folder', '-a'])
+    generate_from_cli(['-e', 'input/library.ecore', '-o', 'some/folder', '--auto-register-package'])
 
     # look at arguments of generate call:
     mock_generate = generator_mock().generate
     model = mock_generator.generate.call_args[0][0]
     path = mock_generator.generate.call_args[0][1]
-    global_vars = mock_generator.generate.call_args[1]['global_vars']
-
+    auto_registration = mock_generator.generate.call_args[1]['auto_register_package']
     assert isinstance(model, pyecore.ecore.EPackage)
     assert model.name == 'library'
     assert path == 'some/folder'
-    assert global_vars['auto_register_package']
-    assert global_vars['out_folder'] == 'some/folder'
-    assert global_vars['ecore_model'] == 'input/library.ecore'
-
+    assert auto_registration
 
 @mock.patch('pyecoregen.cli.EcoreGenerator')
 def test__generate_from_cli(generator_mock, cwd_module_dir):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,6 +16,48 @@ def test__generate_from_cli(generator_mock, cwd_module_dir):
     mock_generate = generator_mock().generate
     model = mock_generator.generate.call_args[0][0]
     path = mock_generator.generate.call_args[0][1]
+    global_vars = mock_generator.generate.call_args[1]['global_vars']
+
+    assert isinstance(model, pyecore.ecore.EPackage)
+    assert model.name == 'library'
+    assert path == 'some/folder'
+    assert not global_vars['auto_register_package']
+    assert global_vars['out_folder'] == 'some/folder'
+    assert global_vars['ecore_model'] == 'input/library.ecore'
+
+
+@mock.patch('pyecoregen.cli.EcoreGenerator')
+def test__generate_from_cli_autoregistration(generator_mock, cwd_module_dir):
+    mock_generator = generator_mock()
+    mock_generator.generate = mock.MagicMock()
+
+    generate_from_cli(['-e', 'input/library.ecore', '-o', 'some/folder', '-a'])
+
+    # look at arguments of generate call:
+    mock_generate = generator_mock().generate
+    model = mock_generator.generate.call_args[0][0]
+    path = mock_generator.generate.call_args[0][1]
+    global_vars = mock_generator.generate.call_args[1]['global_vars']
+
+    assert isinstance(model, pyecore.ecore.EPackage)
+    assert model.name == 'library'
+    assert path == 'some/folder'
+    assert global_vars['auto_register_package']
+    assert global_vars['out_folder'] == 'some/folder'
+    assert global_vars['ecore_model'] == 'input/library.ecore'
+
+
+@mock.patch('pyecoregen.cli.EcoreGenerator')
+def test__generate_from_cli(generator_mock, cwd_module_dir):
+    mock_generator = generator_mock()
+    mock_generator.generate = mock.MagicMock()
+
+    generate_from_cli(['-e', 'input/library.ecore', '-o', 'some/folder'])
+
+    # look at arguments of generate call:
+    mock_generate = generator_mock().generate
+    model = mock_generator.generate.call_args[0][0]
+    path = mock_generator.generate.call_args[0][1]
 
     assert isinstance(model, pyecore.ecore.EPackage)
     assert model.name == 'library'

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -8,9 +8,9 @@ from pyecore.ecore import EPackage, EClass, EReference, EEnum, EAttribute, EInt,
 from pyecoregen.ecore import EcoreGenerator
 
 
-def generate_meta_model(model, output_dir):
+def generate_meta_model(model, output_dir, global_vars=None):
     generator = EcoreGenerator()
-    generator.generate(model, output_dir)
+    generator.generate(model, output_dir, global_vars)
     return importlib.import_module(model.name)
 
 
@@ -289,3 +289,15 @@ def test_eattribute_derived_not_changeable(pygen_output_dir):
 
     with pytest.raises(AttributeError):
         instance.att2 = "test_value2"
+
+
+def test_auto_registration_enabled(pygen_output_dir):
+    rootpkg = EPackage('auto_registration')
+    c1 = EClass('MyClass')
+    rootpkg.eClassifiers.append(c1)
+
+    mm = generate_meta_model(rootpkg, pygen_output_dir, {'auto_register_package' : True})
+
+    from pyecore.resources import global_registry
+    assert mm.nsURI in global_registry
+    assert global_registry[mm.nsURI] is mm.auto_registration


### PR DESCRIPTION
This addition allows the user to ask for the generated package auto-registration in PyEcore 'global_registry'. This added piece of code triggers the addition of each package and sub-packages to the 'global_registry' and avoids further 'manual' registration.

To perform this addition, an option had been added to the cli: `auto-register-package`. This option is not required and pass all the cli variables as Jinja environment variables. The variables passed to the environment are not filtered in case these information could be useful in the future (e.g: for docstring generation or 'verbose' code generation).