### PR TITLE
Feature/global context

### DIFF
--- a/pyecoregen/ecore.py
+++ b/pyecoregen/ecore.py
@@ -108,6 +108,10 @@ class EcoreGenerator(multigen.jinja.JinjaGenerator):
         'templates'
     )
 
+    def __init__(self, auto_register_package=False, **kwargs):
+        self.auto_register_package = auto_register_package
+        super().__init__(**kwargs)
+
     @staticmethod
     def test_type(value, type_):
         """Jinja test to check if an object's class is exactly the tested type."""
@@ -207,6 +211,9 @@ class EcoreGenerator(multigen.jinja.JinjaGenerator):
         """Returns set of passed iterable."""
         return set(value)
 
+    def create_global_context(self, **kwargs):
+        return super().create_global_context(auto_register_package=self.auto_register_packageauto_register_package)
+
     def create_environment(self, **kwargs):
         """
         Return a new Jinja environment.
@@ -237,7 +244,6 @@ class EcoreGenerator(multigen.jinja.JinjaGenerator):
 
         return environment
 
-    def generate(self, model, outfolder, auto_register_package=False):
-        self.environment.globals.update({'auto_register_package': auto_register_package})
+    def generate(self, model, outfolder):
         with pythonic_names():
             super().generate(model, outfolder)

--- a/pyecoregen/ecore.py
+++ b/pyecoregen/ecore.py
@@ -212,7 +212,7 @@ class EcoreGenerator(multigen.jinja.JinjaGenerator):
         return set(value)
 
     def create_global_context(self, **kwargs):
-        return super().create_global_context(auto_register_package=self.auto_register_packageauto_register_package)
+        return super().create_global_context(auto_register_package=self.auto_register_package)
 
     def create_environment(self, **kwargs):
         """

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -8,9 +8,9 @@ from pyecore.ecore import EPackage, EClass, EReference, EEnum, EAttribute, EInt,
 from pyecoregen.ecore import EcoreGenerator
 
 
-def generate_meta_model(model, output_dir, global_vars=None):
-    generator = EcoreGenerator()
-    generator.generate(model, output_dir, global_vars)
+def generate_meta_model(model, output_dir, auto_register_package=None):
+    generator = EcoreGenerator(auto_register_package)
+    generator.generate(model, output_dir)
     return importlib.import_module(model.name)
 
 
@@ -296,7 +296,7 @@ def test_auto_registration_enabled(pygen_output_dir):
     c1 = EClass('MyClass')
     rootpkg.eClassifiers.append(c1)
 
-    mm = generate_meta_model(rootpkg, pygen_output_dir, {'auto_register_package' : True})
+    mm = generate_meta_model(rootpkg, pygen_output_dir, auto_register_package=True)
 
     from pyecore.resources import global_registry
     assert mm.nsURI in global_registry


### PR DESCRIPTION
After changing base library, moved `auto_register_package` from environment to global (template) context.