### PR TITLE
--user-module option added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project 
+adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+### Added
+
+- Added option to auto-register generated package in global registry, see the
+  `--auto-register-package` option.
+- Added option to specify a user module, from where mixin classes. These mixins must then implement
+  all end-user specific code like operations and derived attributes. See the `--user-module`
+  command line option.
+  
+### Fixed
+
+- EDatatype registration.
+- Various derived attribute fixes.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include README.rst LICENSE
+include README.rst CHANGELOG.md LICENSE

--- a/README.rst
+++ b/README.rst
@@ -100,6 +100,6 @@ is then turning into a keyword argument ``my_param``.
     ``--user-module my.custom_mod`` will make the generated code import mixin classes from a module
     ``my.custom_mod``. A generated class with name ``<name>`` then derives from a mixin
     ``<name>Mixin``, which is expected to be part of the user module. If this option is used, the
-    generator also produces a skeleton file which contains all requires mixin classes and methods
-    they have to provide. Usually you copy parts of this template to your own module, which is then
-    checked into version control all your other code.
+    generator also produces a skeleton file which contains all required mixin classes and methods.
+    Usually you copy parts of this template to your own module, which is then checked into version
+    control all your other code.

--- a/README.rst
+++ b/README.rst
@@ -4,10 +4,10 @@ pyecoregen - Python code generation from pyecore models
 |pypi-version| |master-build| |coverage| |license|
 
 .. |master-build| image:: https://travis-ci.org/pyecore/pyecoregen.svg?branch=master
-    :target: https://travis-ci.org/pyecore/pyecoregen
+:target: https://travis-ci.org/pyecore/pyecoregen
 
 .. |pypi-version| image:: https://badge.fury.io/py/pyecoregen.svg
-    :target: https://badge.fury.io/py/pyecoregen
+:target: https://badge.fury.io/py/pyecoregen
 
 .. |coverage| image:: https://coveralls.io/repos/github/pyecore/pyecoregen/badge.svg?branch=master
     :target: https://coveralls.io/github/pyecore/pyecoregen?branch=master
@@ -83,3 +83,23 @@ hold it's root package in ``library_pkg``, you would generate with:
 
     generator = EcoreGenerator()
     generator.generate(library_pkg, 'some/folder')
+
+Generator options
+~~~~~~~~~~~~~~~~~
+
+The end user can control some of the features how the metamodel code is generated. This can be done
+at the command line as well as via programmatic invocation. A command line parameter ``--my-param``
+is then turning into a keyword argument ``my_param``.
+
+``--auto-register-package`` (Default: ``False``)
+    If enabled, the generated packages are automatically added to pyecore's global namespace
+    registry, which makes them available during XMI deserialization.
+
+``--user-module`` (Default: ``None``)
+    If specified, the given string is interpreted as a dotted Python module path. E.g.
+    ``--user-module my.custom_mod`` will make the generated code import mixin classes from a module
+    ``my.custom_mod``. A generated class with name ``<name>`` then derives from a mixin
+    ``<name>Mixin``, which is expected to be part of the user module. If this option is used, the
+    generator also produces a skeleton file which contains all requires mixin classes and methods
+    they have to provide. Usually you copy parts of this template to your own module, which is then
+    checked into version control all your other code.

--- a/pyecoregen/cli.py
+++ b/pyecoregen/cli.py
@@ -8,7 +8,6 @@ import re
 import pyecore.resources
 from pyecoregen.ecore import EcoreGenerator
 
-
 URL_PATTERN = re.compile('^http(s)?://.*')
 
 
@@ -37,6 +36,10 @@ def generate_from_cli(args):
         action='store_true'
     )
     parser.add_argument(
+        '--user-module',
+        help="Dotted name of module with user-provided mixins to import from generated classes.",
+    )
+    parser.add_argument(
         '--verbose',
         '-v',
         help="Increase logging verbosity.",
@@ -47,7 +50,10 @@ def generate_from_cli(args):
 
     configure_logging(parsed_args)
     model = load_model(parsed_args.ecore_model)
-    EcoreGenerator(parsed_args.auto_register_package).generate(model, parsed_args.out_folder)
+    EcoreGenerator(
+        auto_register_package=parsed_args.auto_register_package,
+        user_module=parsed_args.user_module
+    ).generate(model, parsed_args.out_folder)
 
 
 def configure_logging(parsed_args):

--- a/pyecoregen/ecore.py
+++ b/pyecoregen/ecore.py
@@ -108,7 +108,7 @@ class EcoreGenerator(multigen.jinja.JinjaGenerator):
         'templates'
     )
 
-    def __init__(self, auto_register_package=False, **kwargs):
+    def __init__(self, *, auto_register_package=False, **kwargs):
         self.auto_register_package = auto_register_package
         super().__init__(**kwargs)
 

--- a/pyecoregen/ecore.py
+++ b/pyecoregen/ecore.py
@@ -95,6 +95,15 @@ class EcorePackageModuleTask(EcoreTask):
         )
 
 
+class EcorePackageMixinTask(EcorePackageModuleTask):
+    """Generation of optional mixins for user implementations."""
+    template_name = 'mixins.py.skeleton.tpl'
+
+    @staticmethod
+    def filename_for_element(package: ecore.EPackage):
+        return '{}_mixins.py.skeleton'.format(package.name)
+
+
 class EcoreGenerator(multigen.jinja.JinjaGenerator):
     """
     Generation of static Pyecore model classes.
@@ -107,11 +116,6 @@ class EcoreGenerator(multigen.jinja.JinjaGenerator):
             to Pyecore's package registry.
     """
 
-    tasks = [
-        EcorePackageInitTask(formatter=multigen.formatter.format_autopep8),
-        EcorePackageModuleTask(formatter=multigen.formatter.format_autopep8),
-    ]
-
     templates_path = os.path.join(
         os.path.abspath(os.path.dirname(__file__)),
         'templates'
@@ -120,6 +124,14 @@ class EcoreGenerator(multigen.jinja.JinjaGenerator):
     def __init__(self, *, user_module=None, auto_register_package=False, **kwargs):
         self.user_module = user_module
         self.auto_register_package = auto_register_package
+
+        self.tasks = [
+            EcorePackageInitTask(formatter=multigen.formatter.format_autopep8),
+            EcorePackageModuleTask(formatter=multigen.formatter.format_autopep8),
+        ]
+        if self.user_module:
+            self.tasks.append(EcorePackageMixinTask(formatter=multigen.formatter.format_autopep8))
+
         super().__init__(**kwargs)
 
     @staticmethod

--- a/pyecoregen/ecore.py
+++ b/pyecoregen/ecore.py
@@ -96,7 +96,16 @@ class EcorePackageModuleTask(EcoreTask):
 
 
 class EcoreGenerator(multigen.jinja.JinjaGenerator):
-    """Generation of static ecore model classes."""
+    """
+    Generation of static Pyecore model classes.
+
+    Attributes:
+        user_module (str): Dotted module name with user-defined implementations for operations and
+            derived attributes.
+
+        auto_register_package (bool): Flag, whether all generated packages are automatically added
+            to Pyecore's package registry.
+    """
 
     tasks = [
         EcorePackageInitTask(formatter=multigen.formatter.format_autopep8),
@@ -108,7 +117,8 @@ class EcoreGenerator(multigen.jinja.JinjaGenerator):
         'templates'
     )
 
-    def __init__(self, *, auto_register_package=False, **kwargs):
+    def __init__(self, *, user_module=None, auto_register_package=False, **kwargs):
+        self.user_module = user_module
         self.auto_register_package = auto_register_package
         super().__init__(**kwargs)
 
@@ -212,7 +222,10 @@ class EcoreGenerator(multigen.jinja.JinjaGenerator):
         return set(value)
 
     def create_global_context(self, **kwargs):
-        return super().create_global_context(auto_register_package=self.auto_register_package)
+        return super().create_global_context(
+            user_module=self.user_module,
+            auto_register_package=self.auto_register_package
+        )
 
     def create_environment(self, **kwargs):
         """

--- a/pyecoregen/templates/mixins.py.skeleton.tpl
+++ b/pyecoregen/templates/mixins.py.skeleton.tpl
@@ -1,0 +1,6 @@
+{% import 'module_utilities.tpl' as modutil -%}
+"""Mixins to be implemented by user."""
+
+{%- for c in classes -%}
+{{ modutil.generate_mixin(c) }}
+{%- endfor %}

--- a/pyecoregen/templates/mixins.py.skeleton.tpl
+++ b/pyecoregen/templates/mixins.py.skeleton.tpl
@@ -1,4 +1,4 @@
-{% import 'module_utilities.tpl' as modutil -%}
+{% import 'module_utilities.tpl' as modutil with context -%}
 """Mixins to be implemented by user."""
 
 {%- for c in classes -%}

--- a/pyecoregen/templates/module.py.tpl
+++ b/pyecoregen/templates/module.py.tpl
@@ -1,4 +1,4 @@
-{% import 'module_utilities.tpl' as modutil -%}
+{% import 'module_utilities.tpl' as modutil with context -%}
 """Definition of meta model '{{ element.name }}'."""
 from functools import partial
 import pyecore.ecore as Ecore

--- a/pyecoregen/templates/module.py.tpl
+++ b/pyecoregen/templates/module.py.tpl
@@ -5,6 +5,9 @@ from pyecore.ecore import *
 {% for c in imported_classifiers -%}
     from {{ c.ePackage | pyfqn }} import {{ c.name }}
 {% endfor %}
+{% if user_module -%}
+    import {{ user_module }} as _user_module
+{% endif %}
 
 name = '{{ element.name }}'
 nsURI = '{{ element.nsURI | default(boolean=True) }}'
@@ -30,7 +33,10 @@ getEClassifier = partial(Ecore.getEClassifier, searchspace=eClassifiers)
 {#- -------------------------------------------------------------------------------------------- -#}
 
 {%- macro generate_class_header(c) -%}
-class {{ c.name }}({{ c | supertypes }}):
+class {{ c.name }}(
+    {%- if user_module %}_user_module.{{ c.name }}Mixin, {% endif -%}
+    {{ c | supertypes -}}
+):
     {{ c | docstringline -}}
 {% endmacro -%}
 

--- a/pyecoregen/templates/module.py.tpl
+++ b/pyecoregen/templates/module.py.tpl
@@ -1,3 +1,4 @@
+{% import 'module_utilities.tpl' as modutil -%}
 """Definition of meta model '{{ element.name }}'."""
 from functools import partial
 import pyecore.ecore as Ecore
@@ -18,140 +19,13 @@ eClass = EPackage(name=name, nsURI=nsURI, nsPrefix=nsPrefix)
 eClassifiers = {}
 getEClassifier = partial(Ecore.getEClassifier, searchspace=eClassifiers)
 
-{#- -------------------------------------------------------------------------------------------- -#}
-
-{%- macro generate_enum(e) %}
-{{ e.name }} = EEnum('{{ e.name }}', literals=[{{ e.eLiterals | map(attribute='name') | map('pyquotesingle') | join(', ') }}])
-{% endmacro %}
-
-{#- -------------------------------------------------------------------------------------------- -#}
-
-{%- macro generate_edatatype(e) %}
-{{ e.name }} = EDataType('{{ e.name }}', instanceClassName='{{ e.instanceClassName }}')
-{% endmacro %}
-
-{#- -------------------------------------------------------------------------------------------- -#}
-
-{%- macro generate_class_header(c) -%}
-class {{ c.name }}(
-    {%- if user_module %}_user_module.{{ c.name }}Mixin, {% endif -%}
-    {{ c | supertypes -}}
-):
-    {{ c | docstringline -}}
-{% endmacro -%}
-
-{#- -------------------------------------------------------------------------------------------- -#}
-
-{%- macro generate_attribute(a) -%}
-    {% if a.derived %}_{% endif -%}
-    {{ a.name }} = EAttribute({{ a | attrqualifiers }})
-{%- endmacro %}
-
-{#- -------------------------------------------------------------------------------------------- -#}
-
-{%- macro generate_reference(r) -%}
-    {{ r.name }} = EReference({{ r | refqualifiers }})
-{%- endmacro %}
-
-{#- -------------------------------------------------------------------------------------------- -#}
-
-{%- macro generate_derived_attribute(d) -%}
-    @property
-    def {{ d.name }}(self):
-        return self._{{ d.name }}
-
-    {%- if d.changeable %}
-
-    @{{ d.name }}.setter
-    def {{ d.name }}(self, value):
-        self._{{ d.name }} = value
-    {% endif %}
-{%- endmacro %}
-
-{#- -------------------------------------------------------------------------------------------- -#}
-
-{%- macro generate_class_init_args(c) -%}
-    {% if c.eStructuralFeatures %}, *, {% endif -%}
-    {{ c.eStructuralFeatures | map(attribute='name') | map('re_sub', '$', '=None') | join(', ') }}
-{%- endmacro %}
-
-{#- -------------------------------------------------------------------------------------------- -#}
-
-{%- macro generate_feature_init(feature) %}
-    {%- if feature.upperBound == 1 %}
-        if {{ feature.name }} is not None:
-            self.{{ feature.name }} = {{ feature.name }}
-    {%- else %}
-        if {{ feature.name }}:
-            self.{{ feature.name }}.extend({{ feature.name }})
-    {%- endif %}
-{%- endmacro %}
-
-{#- -------------------------------------------------------------------------------------------- -#}
-
-{%- macro generate_class_init(c) %}
-    def __init__(self{{ generate_class_init_args(c) }}, **kwargs):
-    {%- if not c.eSuperTypes %}
-        if kwargs:
-            raise AttributeError('unexpected arguments: {}'.format(kwargs))
-    {%- endif %}
-
-        super().__init__({% if c.eSuperTypes %}**kwargs{% endif %})
-    {%- for feature in c.eStructuralFeatures | reject('type', ecore.EReference) %}
-    {{ generate_feature_init(feature) }}
-    {%- endfor %}
-    {%- for feature in c.eStructuralFeatures | select('type', ecore.EReference) %}
-    {{ generate_feature_init(feature) }}
-    {%- endfor %}
-{%- endmacro %}
-
-{#- -------------------------------------------------------------------------------------------- -#}
-
-{%- macro generate_operation_args(o) -%}
-    {% for p in o.eParameters -%}
-        , {{ p.name }}{% if not p.required %}=None{% endif -%}
-    {% endfor -%}
-{%- endmacro  %}
-
-{#- -------------------------------------------------------------------------------------------- -#}
-
-{%- macro generate_operation(o) %}
-    def {{ o.name }}(self{{ generate_operation_args(o) }}):
-        {{ o | docstringline }}
-        raise NotImplementedError('operation {{ o.name }}(...) not yet implemented')
-{%- endmacro %}
-
-{#- -------------------------------------------------------------------------------------------- -#}
-
-{%- macro generate_class(c) %}
-
-{% if c.abstract %}@abstract
-{% endif -%}
-{{ generate_class_header(c) }}
-{%- for a in c.eAttributes %}
-    {{ generate_attribute(a) -}}
-{% endfor %}
-{%- for r in c.eReferences %}
-    {{ generate_reference(r) -}}
-{% endfor %}
-{% for d in c.eAttributes | selectattr('derived')  %}
-    {{ generate_derived_attribute(d) }}
-{% endfor %}
-{{- generate_class_init(c) }}
-{% for o in c.eOperations %}
-    {{ generate_operation(o) }}
-{% endfor %}
-{%- endmacro %}
-
-{#- -------------------------------------------------------------------------------------------- -#}
-
 {%- for c in element.eClassifiers if c is type(ecore.EEnum) -%}
-{{ generate_enum(c) }}
+{{ modutil.generate_enum(c) }}
 {%- endfor %}
 {% for c in element.eClassifiers if c is type(ecore.EDataType) -%}
-{{ generate_edatatype(c) }}
+{{ modutil.generate_edatatype(c) }}
 {%- endfor %}
 
 {%- for c in classes -%}
-{{ generate_class(c) }}
+{{ modutil.generate_class(c) }}
 {%- endfor %}

--- a/pyecoregen/templates/module_utilities.tpl
+++ b/pyecoregen/templates/module_utilities.tpl
@@ -1,0 +1,150 @@
+{%- macro generate_enum(e) %}
+{{ e.name }} = EEnum('{{ e.name }}', literals=[{{ e.eLiterals | map(attribute='name') | map('pyquotesingle') | join(', ') }}])
+{% endmacro %}
+
+{#- -------------------------------------------------------------------------------------------- -#}
+
+{%- macro generate_edatatype(e) %}
+{{ e.name }} = EDataType('{{ e.name }}', instanceClassName='{{ e.instanceClassName }}')
+{% endmacro %}
+
+{#- -------------------------------------------------------------------------------------------- -#}
+
+{%- macro generate_class_header(c) -%}
+class {{ c.name }}(
+    {%- if user_module %}_user_module.{{ c.name }}Mixin, {% endif -%}
+    {{ c | supertypes -}}
+):
+    {{ c | docstringline -}}
+{% endmacro -%}
+
+{#- -------------------------------------------------------------------------------------------- -#}
+
+{%- macro generate_mixin_header(c) -%}
+class {{ c.name }}Mixin:
+    """User defined mixin class for {{ c.name }}."""
+{% endmacro -%}
+
+{#- -------------------------------------------------------------------------------------------- -#}
+
+{%- macro generate_attribute(a) -%}
+    {% if a.derived %}_{% endif -%}
+    {{ a.name }} = EAttribute({{ a | attrqualifiers }})
+{%- endmacro %}
+
+{#- -------------------------------------------------------------------------------------------- -#}
+
+{%- macro generate_reference(r) -%}
+    {{ r.name }} = EReference({{ r | refqualifiers }})
+{%- endmacro %}
+
+{#- -------------------------------------------------------------------------------------------- -#}
+
+{%- macro generate_derived_attribute(d) -%}
+    @property
+    def {{ d.name }}(self):
+        return self._{{ d.name }}
+
+    {%- if d.changeable %}
+
+    @{{ d.name }}.setter
+    def {{ d.name }}(self, value):
+        self._{{ d.name }} = value
+    {% endif %}
+{%- endmacro %}
+
+{#- -------------------------------------------------------------------------------------------- -#}
+
+{%- macro generate_class_init_args(c) -%}
+    {% if c.eStructuralFeatures %}, *, {% endif -%}
+    {{ c.eStructuralFeatures | map(attribute='name') | map('re_sub', '$', '=None') | join(', ') }}
+{%- endmacro %}
+
+{#- -------------------------------------------------------------------------------------------- -#}
+
+{%- macro generate_feature_init(feature) %}
+    {%- if feature.upperBound == 1 %}
+        if {{ feature.name }} is not None:
+            self.{{ feature.name }} = {{ feature.name }}
+    {%- else %}
+        if {{ feature.name }}:
+            self.{{ feature.name }}.extend({{ feature.name }})
+    {%- endif %}
+{%- endmacro %}
+
+{#- -------------------------------------------------------------------------------------------- -#}
+
+{%- macro generate_class_init(c) %}
+    def __init__(self{{ generate_class_init_args(c) }}, **kwargs):
+    {%- if not c.eSuperTypes %}
+        if kwargs:
+            raise AttributeError('unexpected arguments: {}'.format(kwargs))
+    {%- endif %}
+
+        super().__init__({% if c.eSuperTypes %}**kwargs{% endif %})
+    {%- for feature in c.eStructuralFeatures | reject('type', ecore.EReference) %}
+    {{ generate_feature_init(feature) }}
+    {%- endfor %}
+    {%- for feature in c.eStructuralFeatures | select('type', ecore.EReference) %}
+    {{ generate_feature_init(feature) }}
+    {%- endfor %}
+{%- endmacro %}
+
+{#- -------------------------------------------------------------------------------------------- -#}
+
+{%- macro generate_mixin_init(c) %}
+    def __init__(self{{ generate_class_init_args(c) }}, **kwargs):
+        super().__init__({% if c.eSuperTypes %}**kwargs{% endif %})
+{%- endmacro %}
+
+{#- -------------------------------------------------------------------------------------------- -#}
+
+{%- macro generate_operation_args(o) -%}
+    {% for p in o.eParameters -%}
+        , {{ p.name }}{% if not p.required %}=None{% endif -%}
+    {% endfor -%}
+{%- endmacro  %}
+
+{#- -------------------------------------------------------------------------------------------- -#}
+
+{%- macro generate_operation(o) %}
+    def {{ o.name }}(self{{ generate_operation_args(o) }}):
+        {{ o | docstringline }}
+        raise NotImplementedError('operation {{ o.name }}(...) not yet implemented')
+{%- endmacro %}
+
+{#- -------------------------------------------------------------------------------------------- -#}
+
+{%- macro generate_class(c) %}
+
+{% if c.abstract %}@abstract
+{% endif -%}
+{{ generate_class_header(c) }}
+{%- for a in c.eAttributes %}
+    {{ generate_attribute(a) -}}
+{% endfor %}
+{%- for r in c.eReferences %}
+    {{ generate_reference(r) -}}
+{% endfor %}
+{% if not user_module %}{% for d in c.eAttributes | selectattr('derived')  %}
+    {{ generate_derived_attribute(d) }}
+{% endfor %}{% endif %}
+{{- generate_class_init(c) }}
+{% if not user_module %}{% for o in c.eOperations %}
+    {{ generate_operation(o) }}
+{% endfor %}{% endif %}
+{%- endmacro %}
+
+{#- -------------------------------------------------------------------------------------------- -#}
+
+{%- macro generate_mixin(c) %}
+
+{{ generate_mixin_header(c) }}
+{% for d in c.eAttributes | selectattr('derived')  %}
+    {{ generate_derived_attribute(d) }}
+{% endfor %}
+{{- generate_mixin_init(c) }}
+{% for o in c.eOperations %}
+    {{ generate_operation(o) }}
+{% endfor %}
+{%- endmacro %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,8 +20,7 @@ def pygen_output_dir(cwd_module_dir):
     """Return an empty output directory, part of syspath to allow importing generated code."""
     path = 'output'
     shutil.rmtree(path, ignore_errors=True)
-    original_sys_path = sys.path
     sys.path.append(path)
     yield path
     sys.path.remove(path)
-    shutil.rmtree(path, ignore_errors=False)
+    #shutil.rmtree(path, ignore_errors=False)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,37 +23,25 @@ def test__generate_from_cli(generator_mock, cwd_module_dir):
 
 
 @mock.patch('pyecoregen.cli.EcoreGenerator')
-def test__generate_from_cli_autoregistration(generator_mock, cwd_module_dir):
-    mock_generator = generator_mock()
-    mock_generator.generate = mock.MagicMock()
-
+def test__generate_from_cli__auto_register_package(generator_mock, cwd_module_dir):
     generate_from_cli(['-e', 'input/library.ecore', '-o', 'some/folder', '--auto-register-package'])
 
-    # look at arguments of generate call:
-    mock_generate = generator_mock().generate
-    model = mock_generator.generate.call_args[0][0]
-    path = mock_generator.generate.call_args[0][1]
-    auto_registration = mock_generator.auto_registration
-    assert isinstance(model, pyecore.ecore.EPackage)
-    assert model.name == 'library'
-    assert path == 'some/folder'
-    assert auto_registration
+    # look at arguments of generator instantiation:
+    auto_register_package = generator_mock.call_args[1]['auto_register_package']
+    assert auto_register_package is True  # make sure we don't interpret mock attribute as `True`
+
 
 @mock.patch('pyecoregen.cli.EcoreGenerator')
-def test__generate_from_cli(generator_mock, cwd_module_dir):
-    mock_generator = generator_mock()
-    mock_generator.generate = mock.MagicMock()
+def test__generate_from_cli__user_module(generator_mock, cwd_module_dir):
+    generate_from_cli([
+        '-e', 'input/library.ecore',
+        '-o', 'some/folder',
+        '--user-module', 'some.pkg.module'
+    ])
 
-    generate_from_cli(['-e', 'input/library.ecore', '-o', 'some/folder'])
-
-    # look at arguments of generate call:
-    mock_generate = generator_mock().generate
-    model = mock_generator.generate.call_args[0][0]
-    path = mock_generator.generate.call_args[0][1]
-
-    assert isinstance(model, pyecore.ecore.EPackage)
-    assert model.name == 'library'
-    assert path == 'some/folder'
+    # look at arguments of generator instantiation:
+    user_module = generator_mock.call_args[1]['user_module']
+    assert user_module == 'some.pkg.module'
 
 
 testdata = [

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -9,7 +9,7 @@ from pyecoregen.ecore import EcoreGenerator
 
 
 def generate_meta_model(model, output_dir, auto_register_package=None):
-    generator = EcoreGenerator(auto_register_package)
+    generator = EcoreGenerator(auto_register_package=auto_register_package)
     generator.generate(model, output_dir)
     return importlib.import_module(model.name)
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -318,6 +318,8 @@ def test_user_module_imported(pygen_output_dir):
 def test_user_module_derived_from_mixin(pygen_output_dir):
     rootpkg = EPackage('derived_from_mixin')
     c1 = EClass('MyClass')
+    c1.eOperations.append(EOperation('do_it'))
+    c1.eStructuralFeatures.append(EAttribute('any', EString, derived=True))
     rootpkg.eClassifiers.append(c1)
 
     mm = generate_meta_model(rootpkg, pygen_output_dir, user_module='user_provided.module')

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -311,7 +311,7 @@ def test_user_module_imported(pygen_output_dir):
     c1 = EClass('MyClass')
     rootpkg.eClassifiers.append(c1)
 
-    with pytest.raises(ModuleNotFoundError) as ex:
+    with pytest.raises(ImportError) as ex:
         mm = generate_meta_model(rootpkg, pygen_output_dir, user_module='some_module')
         assert 'some_module' in ex.message
 

--- a/tests/user_provided/module.py
+++ b/tests/user_provided/module.py
@@ -1,0 +1,8 @@
+"""Helper for tests of user_module feature."""
+
+
+class MyClassMixin:
+    """Mixin class, actual implementations set in test cases via mock.patch."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)

--- a/tests/user_provided/module.py
+++ b/tests/user_provided/module.py
@@ -1,8 +1,40 @@
-"""Helper for tests of user_module feature."""
+"""Mixins to be implemented by user.
+
+Implemented for test code in test_templates.py. Search for "user_provided" in test code.
+"""
+
+from unittest import mock
 
 
 class MyClassMixin:
-    """Mixin class, actual implementations set in test cases via mock.patch."""
+    """User defined mixin class for MyClass."""
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    @property
+    def any(self):
+        return self._any
+
+    @any.setter
+    def any(self, value):
+        self._any = value
+
+    def __init__(self, *, any=None, **kwargs):
+        super().__init__()
+
+    do_it = mock.MagicMock()
+
+
+class MyOtherClassMixin:
+    """User defined mixin class for MyOtherClass."""
+
+    @property
+    def other(self):
+        return self._other
+
+    @other.setter
+    def other(self, value):
+        self.mock_other(value)
+        self._other = value
+
+    def __init__(self, *, other=None, **kwargs):
+        super().__init__(**kwargs)
+        self.mock_other = mock.MagicMock()


### PR DESCRIPTION
I added the ability to specify a user-module via command line (or generator argument) ``--user-module``. See the extended README for more information about the results.

The unit tests are currently failing as this code requires at least one change in pyecore that currently is not yet part of the released version:
pyecore/pyecore@671074e26d6c187a1b267b33fdf05761042fde64

This commit allows the mixins to be part of the generated class' inhertance tree.

Please let me know once you created a new pyecore version so I can retrigger the unit tests. Also, please let me know if you would like to see things done differently.

After that we can create a new pyecoregen version.