### PR TITLE
Add missing "templates" in sdist package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include README.rst CHANGELOG.md LICENSE
+include README.rst CHANGELOG.md LICENSE pyecoregen/templates/*


### PR DESCRIPTION
The 'sdist' package (tar.gz) seems taking its extra files from MANIFEST.in (its behavior is still a little fuzzy for me).

fixes #12 