### PR TITLE
Add metamodel depencendies generation (using a dedicated option)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -105,7 +105,7 @@ is then turning into a keyword argument ``my_param``.
     control all your other code.
 
 ``--with-dependencies`` (Default: ``False``)
-    If enabled, the generator also generates all the metamodel that are 'dependencies' of the
-    metamodel sets as input. A metamodel dependency is typically a reference from the input
-    metamodel to another ``.ecore``. Please note that this option introduces a slower code
-    generation as all metamodels must be scanned in order to extract the right dependencies.
+    If enabled, the generator also generates code from all metamodels that are *dependencies* of the
+    input metamodel. A metamodel dependency is typically a reference from the input
+    metamodel to another ``.ecore`` file. Please note that this option introduces slower code
+    generation as all metamodels must be scanned in order to determine dependencies.

--- a/README.rst
+++ b/README.rst
@@ -103,3 +103,9 @@ is then turning into a keyword argument ``my_param``.
     generator also produces a skeleton file which contains all required mixin classes and methods.
     Usually you copy parts of this template to your own module, which is then checked into version
     control all your other code.
+
+``--with-dependencies`` (Default: ``False``)
+    If enabled, the generator also generates all the metamodel that are 'dependencies' of the
+    metamodel sets as input. A metamodel dependency is typically a reference from the input
+    metamodel to another ``.ecore``. Please note that this option introduces a slower code
+    generation as all metamodels must be scanned in order to extract the right dependencies.

--- a/pyecoregen/cli.py
+++ b/pyecoregen/cli.py
@@ -58,7 +58,7 @@ def generate_from_cli(args):
     EcoreGenerator(
         auto_register_package=parsed_args.auto_register_package,
         user_module=parsed_args.user_module,
-        generate_dependencies=parsed_args.with_dependencies
+        with_dependencies=parsed_args.with_dependencies
     ).generate(model, parsed_args.out_folder)
 
 

--- a/pyecoregen/cli.py
+++ b/pyecoregen/cli.py
@@ -40,6 +40,11 @@ def generate_from_cli(args):
         help="Dotted name of module with user-provided mixins to import from generated classes.",
     )
     parser.add_argument(
+        '--with-dependencies',
+        help="Generates code for every metamodel the input metamodel depends on.",
+        action='store_true'
+    )
+    parser.add_argument(
         '--verbose',
         '-v',
         help="Increase logging verbosity.",
@@ -52,7 +57,8 @@ def generate_from_cli(args):
     model = load_model(parsed_args.ecore_model)
     EcoreGenerator(
         auto_register_package=parsed_args.auto_register_package,
-        user_module=parsed_args.user_module
+        user_module=parsed_args.user_module,
+        generate_dependencies=parsed_args.with_dependencies
     ).generate(model, parsed_args.out_folder)
 
 

--- a/pyecoregen/ecore.py
+++ b/pyecoregen/ecore.py
@@ -2,7 +2,6 @@
 import itertools
 import os
 import re
-from typing import Set
 
 import multigen.formatter
 import multigen.jinja
@@ -314,7 +313,7 @@ class EcoreGenerator(multigen.jinja.JinjaGenerator):
                     value.eResource  # force proxy resolution
 
     @staticmethod
-    def load_all_required_resources(root: ecore.EObject) -> Set[Resource]:
+    def load_all_required_resources(root):
         """
         Returns a set of all the resources on which depends a model root.
 

--- a/pyecoregen/ecore.py
+++ b/pyecoregen/ecore.py
@@ -317,7 +317,16 @@ class EcoreGenerator(multigen.jinja.JinjaGenerator):
                         continue
                     value.eResource  # force proxy resolution
 
-    def generate(self, model, outfolder, exclude=None):
+    def generate(self, model, outfolder, *, exclude=None):
+        """
+        Generate model code.
+        
+        Args:
+            model: The meta-model to generate code for.
+            outfolder: Path to the directoty that will contain the generated code.
+            exclude: List of referenced resources for which code was already generated
+                (to prevent regeneration).
+        """
         with pythonic_names():
             check_dependency = self.with_dependencies and model.eResource
             if check_dependency:

--- a/pyecoregen/ecore.py
+++ b/pyecoregen/ecore.py
@@ -148,10 +148,10 @@ class EcoreGenerator(multigen.jinja.JinjaGenerator):
     )
 
     def __init__(self, *, user_module=None, auto_register_package=False,
-                 generate_dependencies=False, **kwargs):
+                 with_dependencies=False, **kwargs):
         self.user_module = user_module
         self.auto_register_package = auto_register_package
-        self.generate_dependencies = generate_dependencies
+        self.with_dependencies = with_dependencies
 
         self.tasks = [
             EcorePackageInitTask(formatter=multigen.formatter.format_autopep8),
@@ -334,7 +334,7 @@ class EcoreGenerator(multigen.jinja.JinjaGenerator):
     def generate(self, model, outfolder):
         with pythonic_names():
             super().generate(model, outfolder)
-            if self.generate_dependencies and model.eResource:
+            if self.with_dependencies and model.eResource:
                 all_resources = self.load_all_required_resources(model)
                 all_resources.remove(model.eResource)
                 for resource in all_resources:

--- a/pyecoregen/ecore.py
+++ b/pyecoregen/ecore.py
@@ -259,7 +259,7 @@ class EcoreGenerator(multigen.jinja.JinjaGenerator):
         if relative_to:
             fqn = '.' + fqn
 
-        return EcoreGenerator.module_path_map.get(fqn, fqn)
+        return cls.module_path_map.get(fqn, fqn)
 
     @staticmethod
     def filter_set(value):

--- a/pyecoregen/templates/module.py.tpl
+++ b/pyecoregen/templates/module.py.tpl
@@ -3,9 +3,9 @@
 from functools import partial
 import pyecore.ecore as Ecore
 from pyecore.ecore import *
-{% for c in imported_classifiers -%}
-    from {{ c.ePackage | pyfqn }} import {{ c.name }}
-{% endfor %}
+{% for package, classifs in imported_classifiers.items() -%}
+    from {{ package | pyfqn }} import {{ classifs|map(attribute='name')|join(', ') }}
+{% endfor -%}
 {% if user_module -%}
     import {{ user_module }} as _user_module
 {% endif %}

--- a/pyecoregen/templates/module.py.tpl
+++ b/pyecoregen/templates/module.py.tpl
@@ -4,7 +4,7 @@ from functools import partial
 import pyecore.ecore as Ecore
 from pyecore.ecore import *
 {% for package, classifs in imported_classifiers.items() -%}
-    from {{ package | pyfqn }} import {{ classifs|map(attribute='name')|join(', ') }}
+    from {{ package|pyfqn }} import {{ classifs|map(attribute='name')|join(', ') }}
 {% endfor -%}
 {% if user_module -%}
     import {{ user_module }} as _user_module

--- a/pyecoregen/templates/package.py.tpl
+++ b/pyecoregen/templates/package.py.tpl
@@ -7,6 +7,9 @@ from .{{ element.name }} import name, nsURI, nsPrefix, eClass
     from .{{ element.name }} import {{ element.eClassifiers | join(', ', attribute='name') }}
 {%- endif %}
 
+{% for package, classifs in imported_classifiers_package.items() -%}
+    from {{ package | pyfqn }} import {{ classifs|map(attribute='name')|join(', ') }}
+{% endfor -%}
 {%- if not element.eSuperPackage %}
     {%- with %}
         {%- set all_references = element | all_contents(ecore.EReference) | list %}

--- a/pyecoregen/templates/package.py.tpl
+++ b/pyecoregen/templates/package.py.tpl
@@ -8,7 +8,7 @@ from .{{ element.name }} import name, nsURI, nsPrefix, eClass
 {%- endif %}
 
 {% for package, classifs in imported_classifiers_package.items() -%}
-    from {{ package | pyfqn }} import {{ classifs|map(attribute='name')|join(', ') }}
+    from {{ package|pyfqn }} import {{ classifs|map(attribute='name')|join(', ') }}
 {% endfor -%}
 {%- if not element.eSuperPackage %}
     {%- with %}

--- a/pyecoregen/templates/package.py.tpl
+++ b/pyecoregen/templates/package.py.tpl
@@ -38,6 +38,8 @@ __all__ = [{{ element.eClassifiers | map(attribute='name') | map('pyquotesingle'
 
 eSubpackages = [{{ element.eSubpackages | map(attribute='name') | join(', ') }}]
 eSuperPackage = {{ element.eSuperPackage.name | default('None') }}
+{{ element.name }}.eSubpackages = eSubpackages
+{{ element.name }}.eSuperPackage = eSuperPackage
 {% if not element.eSuperPackage %}
     {%- for e in element | all_contents(ecore.EReference) | rejectattr('eOpposite') %}
 {{ e.eContainingClass.name }}.{{ e.name }}.eType = {{ e.eType.name }}

--- a/tests/input/A.ecore
+++ b/tests/input/A.ecore
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ecore:EPackage xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="a" nsURI="http://a/1.0" nsPrefix="a">
+  <eClassifiers xsi:type="ecore:EClass" name="A">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="eobject" eType="ecore:EClass http://www.eclipse.org/emf/2002/Ecore#//EObject"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="b" eType="ecore:EClass B.ecore#//B"/>
+  </eClassifiers>
+</ecore:EPackage>

--- a/tests/input/B.ecore
+++ b/tests/input/B.ecore
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ecore:EPackage xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="b" nsURI="http://b/1.0" nsPrefix="b">
-  <eClassifiers xsi:type="ecore:EClass" name="B" eSuperTypes="C.ecore#//C"/>
+  <eClassifiers xsi:type="ecore:EClass" name="B" eSuperTypes="C.ecore#//C">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="to_enum" eType="ecore:EEnum D.ecore#//DEnum"/>
+  </eClassifiers>
 </ecore:EPackage>

--- a/tests/input/B.ecore
+++ b/tests/input/B.ecore
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ecore:EPackage xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="b" nsURI="http://b/1.0" nsPrefix="b">
+  <eClassifiers xsi:type="ecore:EClass" name="B" eSuperTypes="C.ecore#//C"/>
+</ecore:EPackage>

--- a/tests/input/C.ecore
+++ b/tests/input/C.ecore
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ecore:EPackage xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="c" nsURI="http://c/1.0" nsPrefix="c">
+  <eClassifiers xsi:type="ecore:EClass" name="C"/>
+</ecore:EPackage>

--- a/tests/input/D.ecore
+++ b/tests/input/D.ecore
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ecore:EPackage xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="d" nsURI="http://d/1.0" nsPrefix="d">
+  <eClassifiers xsi:type="ecore:EEnum" name="DEnum">
+    <eLiterals name="DVAL"/>
+  </eClassifiers>
+</ecore:EPackage>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -44,6 +44,19 @@ def test__generate_from_cli__user_module(generator_mock, cwd_module_dir):
     assert user_module == 'some.pkg.module'
 
 
+@mock.patch('pyecoregen.cli.EcoreGenerator')
+def test__generate_from_cli__with_dependencies(generator_mock, cwd_module_dir):
+    generate_from_cli([
+        '-e', 'input/A.ecore',
+        '-o', 'some/folder',
+        '--with-dependencies'
+    ])
+
+    # look at arguments of generator instantiation:
+    with_dependencies = generator_mock.call_args[1]['with_dependencies']
+    assert with_dependencies is True  # make sure we don't interpret mock attribute as `True`
+
+
 testdata = [
     ('/tmp/test.ecore', pyecore.resources.URI),
     ('C:\\test.ecore', pyecore.resources.URI),

--- a/tests/test_dependencies_generation.py
+++ b/tests/test_dependencies_generation.py
@@ -23,9 +23,14 @@ def test_cross_resource_packages(generated_metamodel):
     A = generated_metamodel.A
     B = A.b.eType
     C = B.eClass.eSuperTypes[0].python_class
+    D = B.to_enum.eType
     A_package = A.eClass.ePackage
     B_package = B.eClass.ePackage
     C_package = C.eClass.ePackage
+    D_package = D.eClass.ePackage
     assert A_package is not B_package
     assert A_package is not C_package
     assert B_package is not C_package
+    assert A_package is not D_package
+    assert B_package is not D_package
+    assert C_package is not D_package

--- a/tests/test_dependencies_generation.py
+++ b/tests/test_dependencies_generation.py
@@ -1,0 +1,31 @@
+import importlib
+from os import path
+
+import pytest
+
+import pyecore.ecore as Ecore
+from pyecore.resources import ResourceSet, URI
+from pyecore.utils import DynamicEPackage
+from pyecoregen.ecore import EcoreGenerator
+
+
+@pytest.fixture(scope='module')
+def generated_metamodel(pygen_output_dir):
+    rset = ResourceSet()
+    resource = rset.get_resource(URI('input/A.ecore'))
+    library_model = resource.contents[0]
+    generator = EcoreGenerator(with_dependencies=True)
+    generator.generate(library_model, pygen_output_dir)
+    return importlib.import_module('a')
+
+
+def test_cross_resource_packages(generated_metamodel):
+    A = generated_metamodel.A
+    B = A.b.eType
+    C = B.eClass.eSuperTypes[0].python_class
+    A_package = A.eClass.ePackage
+    B_package = B.eClass.ePackage
+    C_package = C.eClass.ePackage
+    assert A_package is not B_package
+    assert A_package is not C_package
+    assert B_package is not C_package


### PR DESCRIPTION
When metamodels are split in many metamodels, it can become tedious to manually generate each metamodels by hand (and not forgot any). This new option: `--with-dependencies`, generates the input metamodel code and also generates the code of metamodels it depends on by scanning the input metamodel (and dependencies, recursively). 

This option is set to `False` by default in order to be able to generate only the metamodel code without dependencies if needed. 