### PR TITLE
Fix missing EDataTypes imports and remove resolve_all_proxies method

### DIFF
--- a/pyecoregen/ecore.py
+++ b/pyecoregen/ecore.py
@@ -93,7 +93,7 @@ class EcorePackageModuleTask(EcoreTask):
 
         attributes = itertools.chain(*(c.eAttributes for c in classes))
         attributes_types = (a.eType for a in attributes)
-        imported |= {t for t in attributes_types if t.ePackage not in {p, ecore.eClass}}
+        imported |= {t for t in attributes_types if t.ePackage not in {p, ecore.eClass, None}}
 
         imported_dict = {}
         for classifier in imported:

--- a/tests/input/B.ecore
+++ b/tests/input/B.ecore
@@ -3,5 +3,6 @@
     xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="b" nsURI="http://b/1.0" nsPrefix="b">
   <eClassifiers xsi:type="ecore:EClass" name="B" eSuperTypes="C.ecore#//C">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="to_enum" eType="ecore:EEnum D.ecore#//DEnum"/>
+     <eStructuralFeatures xsi:type="ecore:EAttribute" name="custom_datatype" eType="ecore:EDataType D.ecore#//MyDatatype"/>
   </eClassifiers>
 </ecore:EPackage>

--- a/tests/input/D.ecore
+++ b/tests/input/D.ecore
@@ -4,4 +4,5 @@
   <eClassifiers xsi:type="ecore:EEnum" name="DEnum">
     <eLiterals name="DVAL"/>
   </eClassifiers>
+  <eClassifiers xsi:type="ecore:EDataType" name="MyDatatype" instanceClassName="java.lang.String"/>
 </ecore:EPackage>

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -182,14 +182,16 @@ def test_class_with_derived_features(pygen_output_dir):
 
 def test_various_datatypes(pygen_output_dir):
     rootpkg = EPackage('datatypes')
-    data1 = EDataType('Data1', instanceClassName='java.lang.Integer')
+    data1 = EDataType('Data1', instanceClassName='int')
     data2 = EDataType('Data2', instanceClassName='Unknown')
-    rootpkg.eClassifiers.extend([data1, data2])
+    data3 = EDataType('Data3', instanceClassName='java.lang.Integer')
+    rootpkg.eClassifiers.extend([data1, data2, data3])
 
     mm = generate_meta_model(rootpkg, pygen_output_dir)
 
     gendata1 = mm.eClassifiers['Data1']
     gendata2 = mm.eClassifiers['Data2']
+    gendata3 = mm.eClassifiers['Data3']
 
     assert gendata1 is mm.Data1
     assert mm.Data1.eType is int
@@ -197,6 +199,9 @@ def test_various_datatypes(pygen_output_dir):
     assert gendata2 is mm.Data2
     assert mm.Data2.eType is object
     assert isinstance(mm.Data2.default_value, object)
+    assert gendata3 is mm.Data3
+    assert mm.Data3.eType is int
+    assert mm.Data3.default_value is None
 
 
 def test_class_with_feature_many(pygen_output_dir):


### PR DESCRIPTION
`EDatatypes` references were not gathered by the method that computes the import classes, only `EEnum` were filtered. The new 'condition' upon the import classes search adds the missing `EDataTypes` imports and removes the need for early proxy resolving. This should also improve a little bit performances on big metamodel with many dependencies.