### PR TITLE
Remove Python 3.3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project 
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project
 adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## 0.4.2
+### Fixed
+
+- Missing 'templates' in the sdist package. The sdist package (`.tar.gz`) is
+  built using information of the `MANIFEST.in` for non-source files. The
+  templates were simply missing in it. 
 
 ## 0.4.1
 ### Fixed
@@ -17,7 +24,7 @@ adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 - Added option to specify a user module, from where mixin classes. These mixins must then implement
   all end-user specific code like operations and derived attributes. See the `--user-module`
   command line option.
-  
+
 ### Fixed
 
 - EDatatype registration.

--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ with a simple:
 
     $ pip install pyecoregen
 
-The library works with any version of Python >= 3.3.
+The library works with any version of Python >= 3.4.
 
 Usage
 -----

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ class PyTest(TestCommand):
 
 setup(
     name="pyecoregen",
-    version='0.4.1',
+    version='0.4.2',
     description="Model to text framework for PyEcore, including the Ecore to Python generator",
     long_description=open('README.rst').read(),
     keywords="model metamodel EMF Ecore code generator",


### PR DESCRIPTION
Beside the modifications I made, I checked, but I didn't see other places where Python 3.3 would have been mentioned.