### PR TITLE
Fix missing cross-EDatatypes

### DIFF
--- a/pyecoregen/ecore.py
+++ b/pyecoregen/ecore.py
@@ -93,7 +93,7 @@ class EcorePackageModuleTask(EcoreTask):
 
         attributes = itertools.chain(*(c.eAttributes for c in classes))
         attributes_types = (a.eType for a in attributes)
-        imported |= {t for t in attributes_types if t.ePackage not in {p, ecore.eClass}}
+        imported |= {t for t in attributes_types if t.ePackage not in {p, ecore.eClass, None}}
 
         imported_dict = {}
         for classifier in imported:

--- a/tests/input/B.ecore
+++ b/tests/input/B.ecore
@@ -3,5 +3,6 @@
     xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="b" nsURI="http://b/1.0" nsPrefix="b">
   <eClassifiers xsi:type="ecore:EClass" name="B" eSuperTypes="C.ecore#//C">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="to_enum" eType="ecore:EEnum D.ecore#//DEnum"/>
+     <eStructuralFeatures xsi:type="ecore:EAttribute" name="custom_datatype" eType="ecore:EDataType D.ecore#//MyDatatype"/>
   </eClassifiers>
 </ecore:EPackage>

--- a/tests/input/D.ecore
+++ b/tests/input/D.ecore
@@ -4,4 +4,5 @@
   <eClassifiers xsi:type="ecore:EEnum" name="DEnum">
     <eLiterals name="DVAL"/>
   </eClassifiers>
+  <eClassifiers xsi:type="ecore:EDataType" name="MyDatatype" instanceClassName="java.lang.String"/>
 </ecore:EPackage>


### PR DESCRIPTION
The current implementation filter the `EAttribute` types that need to be imported from other metamodels and only gathers `EEnum`. This behavior is the almost complete, but it misses the potential external `EDatatype`.

This commit fix this, removing by the same occasion the need for the `resolve_all_proxies(...)` method. The result is a more fluent external element search and a slightly performances improvement. Tests had been also enhanced in order to catch such a case.