### PR TITLE
Add support for default values in the generated code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project
 adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 0.4.3
+### Added
+
+- Added option to auto-generate the Python code for the metamodel's dependencies,
+  see the `--with-dependencies` option.
+
+## Fixed
+- Missing imports to `EDataType` references that are contained in a metamodel dependency.
+- Missing default value generation for `EAttribute`.
+- Missing `eSubpackages` and `eSuperPackages` at module level.
+
+## Removed
+- Removed support for Python 3.3.
+
 ## 0.4.2
 ### Fixed
 
 - Missing 'templates' in the sdist package. The sdist package (`.tar.gz`) is
   built using information of the `MANIFEST.in` for non-source files. The
-  templates were simply missing in it. 
+  templates were simply missing in it.
 
 ## 0.4.1
 ### Fixed

--- a/pyecoregen/adapter.py
+++ b/pyecoregen/adapter.py
@@ -8,6 +8,13 @@ from pyecore import ecore
 _logger = logging.getLogger(__name__)
 
 
+def fix_name_clash(value):
+    while keyword.iskeyword(value):
+        # appending underscores is a typical way of removing name clashes in Python:
+        value += '_'
+    return value
+
+
 @contextlib.contextmanager
 def pythonic_names():
     original_get_attribute = ecore.ENamedElement.__getattribute__
@@ -16,9 +23,7 @@ def pythonic_names():
         value = original_get_attribute(self, name)
 
         if name == 'name':
-            while keyword.iskeyword(value):
-                # appending underscores is a typical way of removing name clashes in Python:
-                value += '_'
+            value = fix_name_clash(value)
 
         return value
 

--- a/tests/test_ecore.py
+++ b/tests/test_ecore.py
@@ -3,7 +3,7 @@ from unittest import mock
 
 import pytest
 
-from pyecore.ecore import EPackage, EClass, EEnum
+from pyecore.ecore import EPackage, EClass, EEnum, EAttribute, EString, EInt
 from pyecoregen.ecore import EcoreTask, EcorePackageInitTask, EcorePackageModuleTask, EcoreGenerator
 
 
@@ -83,3 +83,31 @@ def test__ecore_generator__test_opposite_before_self():
 
     elements = [mock.sentinel.OPPOSITE]
     assert not EcoreGenerator.test_opposite_before_self(mock_element, elements)
+
+
+def test__ecore_generator__manage_default_value_simple_types():
+    attribute = EAttribute('with_default', EString)
+    attribute.defaultValueLiteral = 'str_val'
+    result = EcoreGenerator.manage_default_value(attribute)
+    assert result == "'str_val'"
+
+    attribute.eType = EInt
+    attribute.defaultValueLiteral = '123456'
+    result = EcoreGenerator.manage_default_value(attribute)
+    assert result == 123456
+
+
+def test__ecore_generator__manage_default_value_enumeration():
+    enumeration = EEnum('MyEnum', literals=('None_', 'A', 'B'))
+    attribute = EAttribute('with_default', enumeration)
+    attribute.defaultValueLiteral = 'A'
+    result = EcoreGenerator.manage_default_value(attribute)
+    assert result == 'MyEnum.A'
+
+    attribute.defaultValueLiteral = 'None_'
+    result = EcoreGenerator.manage_default_value(attribute)
+    assert result == 'MyEnum.None_'
+
+    attribute.defaultValueLiteral = 'None'
+    result = EcoreGenerator.manage_default_value(attribute)
+    assert result == 'MyEnum.None_'

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -344,3 +344,27 @@ def test_user_module_derived_from_mixin(pygen_output_dir):
     assert not c.do_it.called
     c.do_it()
     assert c.do_it.called
+
+
+def test_user_module_derived_from_mixin(pygen_output_dir):
+    rootpkg = EPackage('with_default_values')
+    e1 = EEnum('MyEnum', literals=('None_', 'A', 'B'))
+    rootpkg.eClassifiers.append(e1)
+
+    c1 = EClass('MyClass')
+    a1 = EAttribute('a1', EString)
+    a1.defaultValueLiteral = 'my_str'
+
+    a2 = EAttribute('a2', EInt)
+    a2.defaultValueLiteral = '7654321'
+
+    a3 = EAttribute('a3', e1)
+    a3.defaultValueLiteral = 'None'
+    c1.eStructuralFeatures.extend([a1, a2, a3])
+    rootpkg.eClassifiers.append(c1)
+
+    mm = generate_meta_model(rootpkg, pygen_output_dir)
+
+    assert mm.MyClass.a1.default_value == 'my_str'
+    assert mm.MyClass.a2.default_value == 7654321
+    assert mm.MyClass.a3.default_value == mm.MyEnum.None_


### PR DESCRIPTION
This PR adds the support for the generation of default values in the metamodel code. The added code is pretty straight forward, but there is two special points: 

1. the `str` type values, the default value **must** contain the quotes in order to generate a string value in the Python code,
2. the enumeration is a little bit more cumbersome as the literal could be a Python reserved keyword (see the `notation.ecore` metamodel from the gmf notation project to see such examples).  