### PR TITLE
Add support for derived collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project
 adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 0.4.4
+### Added
+
+- Added generation of "many" derived `EStructuralFeature` as `EDerivedCollection`.
+
+### Fixed
+- Generation of "single" derived `EStructuralFeature`.
+
 ## 0.4.3
 ### Added
 
 - Added option to auto-generate the Python code for the metamodel's dependencies,
   see the `--with-dependencies` option.
 
-## Fixed
+### Fixed
 - Missing imports to `EDataType` references that are contained in a metamodel dependency.
 - Missing default value generation for `EAttribute`.
 - Missing `eSubpackages` and `eSuperPackages` at module level.
 
-## Removed
+### Removed
 - Removed support for Python 3.3.
 
 ## 0.4.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## 0.4.4
-### Added
-
 - Added generation of "many" derived `EStructuralFeature` as `EDerivedCollection`.
 
 ### Fixed
-- Generation of "single" derived `EStructuralFeature`.
+- Missing genration of "single" derived `EReference`.
 
 ## 0.4.3
 ### Added

--- a/pyecoregen/ecore.py
+++ b/pyecoregen/ecore.py
@@ -219,7 +219,7 @@ class EcoreGenerator(multigen.jinja.JinjaGenerator):
         elif value.derived:
             qualifiers.update(name='{v.name!r}'.format(v=value))
         if value.transient:
-            qualifiers.update(transient=value.transient)
+            qualifiers.update(transient=True)
 
         return ', '.join('{}={}'.format(k, v) for k, v in qualifiers.items())
 
@@ -239,7 +239,7 @@ class EcoreGenerator(multigen.jinja.JinjaGenerator):
         if value.defaultValueLiteral:
             qualifiers.update(default_value=cls.manage_default_value(attribute=value))
         if value.transient:
-            qualifiers.update(transient=value.transient)
+            qualifiers.update(transient=True)
 
         return ', '.join('{}={}'.format(k, v) for k, v in qualifiers.items())
 
@@ -315,7 +315,7 @@ class EcoreGenerator(multigen.jinja.JinjaGenerator):
         environment.filters.update({
             'docstringline': self.filter_docstringline,
             'pyquotesingle': self.filter_pyquotesingle,
-            'derivename': self.filter_derived_name,
+            'derivedname': self.filter_derived_name,
             'refqualifiers': self.filter_refqualifiers,
             'attrqualifiers': self.filter_attrqualifiers,
             'supertypes': self.filter_supertypes,

--- a/pyecoregen/ecore.py
+++ b/pyecoregen/ecore.py
@@ -62,7 +62,7 @@ class EcorePackageInitTask(EcoreTask):
 
         references = itertools.chain(*(c.eAllReferences() for c in classes))
         references_types = (r.eType for r in references)
-        imported = {c for c in references_types if c.ePackage is not p}
+        imported = {c for c in references_types if getattr(c, 'ePackage', p) is not p}
 
         imported_dict = {}
         for classifier in imported:
@@ -201,14 +201,25 @@ class EcoreGenerator(multigen.jinja.JinjaGenerator):
         return '\'{}\''.format(value) if value is not None else ''
 
     @staticmethod
+    def filter_derived_name(value: ecore.EStructuralFeature):
+        if value.derived and not value.many:
+            return '_' + value.name
+        return value.name
+
+    @staticmethod
     def filter_refqualifiers(value: ecore.EReference):
         qualifiers = dict(
             ordered=value.ordered,
             unique=value.unique,
             containment=value.containment,
+            derived=value.derived,
         )
         if value.many:
             qualifiers.update(upper=-1)
+        elif value.derived:
+            qualifiers.update(name='{v.name!r}'.format(v=value))
+        if value.transient:
+            qualifiers.update(transient=value.transient)
 
         return ', '.join('{}={}'.format(k, v) for k, v in qualifiers.items())
 
@@ -223,10 +234,12 @@ class EcoreGenerator(multigen.jinja.JinjaGenerator):
             qualifiers.update(iD=value.iD)
         if value.many:
             qualifiers.update(upper=-1)
-        if value.derived:
+        elif value.derived:
             qualifiers.update(name='{v.name!r}'.format(v=value))
         if value.defaultValueLiteral:
             qualifiers.update(default_value=cls.manage_default_value(attribute=value))
+        if value.transient:
+            qualifiers.update(transient=value.transient)
 
         return ', '.join('{}={}'.format(k, v) for k, v in qualifiers.items())
 
@@ -302,6 +315,7 @@ class EcoreGenerator(multigen.jinja.JinjaGenerator):
         environment.filters.update({
             'docstringline': self.filter_docstringline,
             'pyquotesingle': self.filter_pyquotesingle,
+            'derivename': self.filter_derived_name,
             'refqualifiers': self.filter_refqualifiers,
             'attrqualifiers': self.filter_attrqualifiers,
             'supertypes': self.filter_supertypes,

--- a/pyecoregen/templates/module_utilities.tpl
+++ b/pyecoregen/templates/module_utilities.tpl
@@ -28,14 +28,14 @@ class {{ c.name }}Mixin:
 {#- -------------------------------------------------------------------------------------------- -#}
 
 {%- macro generate_attribute(a) -%}
-    {{ a | derivename }} = EAttribute({{ a | attrqualifiers }}
+    {{ a | derivedname }} = EAttribute({{ a | attrqualifiers }}
                                       {%- if a.derived and a.many %}, {{ generate_derived_fragment(a) }}{% endif %})
 {%- endmacro %}
 
 {#- -------------------------------------------------------------------------------------------- -#}
 
 {%- macro generate_reference(r) -%}
-    {{ r | derivename }} = EReference({{ r | refqualifiers }}
+    {{ r | derivedname }} = EReference({{ r | refqualifiers }}
                                       {%- if r.derived and r.many %}, {{ generate_derived_fragment(r) }}{% endif %})
 {%- endmacro %}
 

--- a/pyecoregen/templates/module_utilities.tpl
+++ b/pyecoregen/templates/module_utilities.tpl
@@ -28,29 +28,42 @@ class {{ c.name }}Mixin:
 {#- -------------------------------------------------------------------------------------------- -#}
 
 {%- macro generate_attribute(a) -%}
-    {% if a.derived %}_{% endif -%}
-    {{ a.name }} = EAttribute({{ a | attrqualifiers }})
+    {{ a | derivename }} = EAttribute({{ a | attrqualifiers }}
+                                      {%- if a.derived and a.many %}, {{ generate_derived_fragment(a) }}{% endif %})
 {%- endmacro %}
 
 {#- -------------------------------------------------------------------------------------------- -#}
 
 {%- macro generate_reference(r) -%}
-    {{ r.name }} = EReference({{ r | refqualifiers }})
+    {{ r | derivename }} = EReference({{ r | refqualifiers }}
+                                      {%- if r.derived and r.many %}, {{ generate_derived_fragment(r) }}{% endif %})
 {%- endmacro %}
+
+{%- macro generate_derived_fragment(f) -%}
+derived_class={% if user_module %}_user_module.{% endif %}Derived{{ f.name | capitalize }}
+{%- endmacro -%}
 
 {#- -------------------------------------------------------------------------------------------- -#}
 
-{%- macro generate_derived_attribute(d) -%}
+{%- macro generate_derived_single(d) -%}
     @property
     def {{ d.name }}(self):
-        return self._{{ d.name }}
+        raise NotImplementedError('Missing implementation for {{ d.name }}')
 
     {%- if d.changeable %}
 
     @{{ d.name }}.setter
     def {{ d.name }}(self, value):
-        self._{{ d.name }} = value
+        raise NotImplementedError('Missing implementation for {{ d.name }}')
     {% endif %}
+{%- endmacro %}
+
+{#- -------------------------------------------------------------------------------------------- -#}
+
+{%- macro generate_derived_collection(d) -%}
+
+class Derived{{ d.name | capitalize }}(EDerivedCollection):
+    pass
 {%- endmacro %}
 
 {#- -------------------------------------------------------------------------------------------- -#}
@@ -117,6 +130,10 @@ class {{ c.name }}Mixin:
 
 {%- macro generate_class(c) %}
 
+{% if not user_module %}{% for d in c.eStructuralFeatures | selectattr('derived') | selectattr('many') %}
+{{ generate_derived_collection(d) }}
+{% endfor %}{% endif %}
+
 {% if c.abstract %}@abstract
 {% endif -%}
 {{ generate_class_header(c) }}
@@ -126,8 +143,8 @@ class {{ c.name }}Mixin:
 {%- for r in c.eReferences %}
     {{ generate_reference(r) -}}
 {% endfor %}
-{% if not user_module %}{% for d in c.eAttributes | selectattr('derived')  %}
-    {{ generate_derived_attribute(d) }}
+{% if not user_module %}{% for d in c.eStructuralFeatures | selectattr('derived') | rejectattr('many') %}
+    {{ generate_derived_single(d) }}
 {% endfor %}{% endif %}
 {{- generate_class_init(c) }}
 {% if not user_module %}{% for o in c.eOperations %}
@@ -139,9 +156,13 @@ class {{ c.name }}Mixin:
 
 {%- macro generate_mixin(c) %}
 
+{% for d in c.eStructuralFeatures | selectattr('derived') | selectattr('many')  %}
+{{ generate_derived_collection(d) }}
+{% endfor %}
+
 {{ generate_mixin_header(c) }}
-{% for d in c.eAttributes | selectattr('derived')  %}
-    {{ generate_derived_attribute(d) }}
+{% for d in c.eStructuralFeatures | selectattr('derived') | rejectattr('many') %}
+    {{ generate_derived_single(d) }}
 {% endfor %}
 {{- generate_mixin_init(c) }}
 {% for o in c.eOperations %}

--- a/pyecoregen/templates/package.py.tpl
+++ b/pyecoregen/templates/package.py.tpl
@@ -42,13 +42,13 @@ eSuperPackage = {{ element.eSuperPackage.name | default('None') }}
 {{ element.name }}.eSuperPackage = eSuperPackage
 {% if not element.eSuperPackage %}
     {%- for e in element | all_contents(ecore.EReference) | rejectattr('eOpposite') %}
-{{ e.eContainingClass.name }}.{{ e | derivename }}.eType = {{ e.eType.name }}
+{{ e.eContainingClass.name }}.{{ e | derivedname }}.eType = {{ e.eType.name }}
     {%- endfor %}
     {%- with opposites = element | all_contents(ecore.EReference) | selectattr('eOpposite') | list %}
         {%- for e in opposites %}
-{{ e.eContainingClass.name }}.{{ e | derivename }}.eType = {{ e.eType.name }}
+{{ e.eContainingClass.name }}.{{ e | derivedname }}.eType = {{ e.eType.name }}
             {%- if e is opposite_before_self(opposites) %}
-{{ e.eContainingClass.name }}.{{ e | derivename }}.eOpposite = {{ e.eOpposite.eContainingClass.name }}.{{ e.eOpposite.name }}
+{{ e.eContainingClass.name }}.{{ e | derivedname }}.eOpposite = {{ e.eOpposite.eContainingClass.name }}.{{ e.eOpposite.name }}
             {%- endif %}
         {%- endfor %}
     {%- endwith %}

--- a/pyecoregen/templates/package.py.tpl
+++ b/pyecoregen/templates/package.py.tpl
@@ -42,13 +42,13 @@ eSuperPackage = {{ element.eSuperPackage.name | default('None') }}
 {{ element.name }}.eSuperPackage = eSuperPackage
 {% if not element.eSuperPackage %}
     {%- for e in element | all_contents(ecore.EReference) | rejectattr('eOpposite') %}
-{{ e.eContainingClass.name }}.{{ e.name }}.eType = {{ e.eType.name }}
+{{ e.eContainingClass.name }}.{{ e | derivename }}.eType = {{ e.eType.name }}
     {%- endfor %}
     {%- with opposites = element | all_contents(ecore.EReference) | selectattr('eOpposite') | list %}
         {%- for e in opposites %}
-{{ e.eContainingClass.name }}.{{ e.name }}.eType = {{ e.eType.name }}
+{{ e.eContainingClass.name }}.{{ e | derivename }}.eType = {{ e.eType.name }}
             {%- if e is opposite_before_self(opposites) %}
-{{ e.eContainingClass.name }}.{{ e.name }}.eOpposite = {{ e.eOpposite.eContainingClass.name }}.{{ e.eOpposite.name }}
+{{ e.eContainingClass.name }}.{{ e | derivename }}.eOpposite = {{ e.eOpposite.eContainingClass.name }}.{{ e.eOpposite.name }}
             {%- endif %}
         {%- endfor %}
     {%- endwith %}

--- a/tests/input/library.ecore
+++ b/tests/input/library.ecore
@@ -27,6 +27,9 @@
     <eAnnotations xmi:id="_cPfS7h9KEeeOINGRvT6ccg" source="genmymodel">
       <details xmi:id="_cPfS7x9KEeeOINGRvT6ccg" key="uuid" value="_5AMH4MSREDSrHKQOAiwNVw"/>
     </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" xmi:id="_cPfS6R9KEeeOINGRvT63456" transient="true" derived="true" name="ages" upperBound="-1">
+        <eType xsi:type="ecore:EDataType" href="http://www.eclipse.org/emf/2002/Ecore#//EInt"/>
+    </eStructuralFeatures>
     <eStructuralFeatures xsi:type="ecore:EAttribute" xmi:id="_cPfS8B9KEeeOINGRvT6ccg" name="name">
       <eAnnotations xmi:id="_cPfS8R9KEeeOINGRvT6ccg" source="genmymodel">
         <details xmi:id="_cPfS8h9KEeeOINGRvT6ccg" key="uuid" value="__hNk4MSREDSrHKQOAiwNVw"/>
@@ -54,6 +57,7 @@
         <details xmi:id="_cPfTAh9KEeeOINGRvT6ccg" key="uuid" value="_ejBQEMSSEDSrHKQOAiwNVw"/>
       </eAnnotations>
     </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EReference" xmi:id="_cPfS-B9KEeeOINGRvT6123" name="moreThan20" upperBound="-1" eType="_cPfS4h9KEeeOINGRvT6ccg" containment="true" derived="true" transient="true"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" xmi:id="_cPfTBB9KEeeOINGRvT6ccg" name="Writer">
     <eAnnotations xmi:id="_cPfTBR9KEeeOINGRvT6ccg" source="genmymodel">

--- a/tests/test_generated_library.py
+++ b/tests/test_generated_library.py
@@ -164,3 +164,13 @@ def test_static_init_bad_argument(generated_library):
 def test_static_init_dynamic_epackage_bad_value(generated_library):
     with pytest.raises(Ecore.BadValueError):
         DynamicEPackage(generated_library)
+
+
+def test_static_derived_attributes(generated_library):
+    lib = generated_library.Library()
+    with pytest.raises(AttributeError):
+        len(lib.ages)
+    with pytest.raises(AttributeError):
+        len(lib.moreThan20)
+    with pytest.raises(AttributeError):
+        lib.ages.append(5)


### PR DESCRIPTION
The derived collection generation relies on the generation of a class inheriting from the `DerivedCollection` base class. Each generated class will owns the dedicated implementation of the collection. The location of each generated class depends on if the user asked for the mixins generations.