### PR TITLE
Generate TextX compatible Classes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -112,7 +112,7 @@ is then turning into a keyword argument ``my_param``.
 
 ``--textX`` (Default: ``False``)
 	If enabled, the generator generates textX compatible classes. The generated classes should be passed
-	as `custom classes`_ to textX metamodel. The classes can be found in the generated ``classes`` variable.
+	as `custom classes`_ to a metamodel. The classes can be found in the generated ``classes`` variable.
 	Using the generated classes will result in an ecore and textX compatible model.
 
 	.. _custom classes: https://textx.readthedocs.io/en/latest/metamodel/#custom-classes

--- a/README.rst
+++ b/README.rst
@@ -109,3 +109,10 @@ is then turning into a keyword argument ``my_param``.
     input metamodel. A metamodel dependency is typically a reference from the input
     metamodel to another ``.ecore`` file. Please note that this option introduces slower code
     generation as all metamodels must be scanned in order to determine dependencies.
+
+``--textX`` (Default: ``False``)
+	If enabled, the generator generates textX compatible classes. The generated classes should be passed
+	as `custom classes`_ to textX metamodel. The classes can be found in the generated ``classes`` variable.
+	Using the generated classes will result in an ecore and textX compatible model.
+
+	.. _custom classes: https://textx.readthedocs.io/en/latest/metamodel/#custom-classes

--- a/pyecoregen/cli.py
+++ b/pyecoregen/cli.py
@@ -50,6 +50,10 @@ def generate_from_cli(args):
         help="Increase logging verbosity.",
         action='count'
     )
+    parser.add_argument(
+        '--textX',
+        help="Generate textX compatible classes",
+        action='store_true')
 
     parsed_args = parser.parse_args(args)
 
@@ -58,7 +62,8 @@ def generate_from_cli(args):
     EcoreGenerator(
         auto_register_package=parsed_args.auto_register_package,
         user_module=parsed_args.user_module,
-        with_dependencies=parsed_args.with_dependencies
+        with_dependencies=parsed_args.with_dependencies,
+        textX=parsed_args.textX
     ).generate(model, parsed_args.out_folder)
 
 

--- a/pyecoregen/ecore.py
+++ b/pyecoregen/ecore.py
@@ -141,6 +141,8 @@ class EcoreGenerator(multigen.jinja.JinjaGenerator):
 
         with_dependencies (bool): Flag, whether the code for direct and transitive dependencies of
             the metamodel sets as input should be generated.
+
+        textX (bool): Flag, whether textX compatible code should be generated.
     """
 
     templates_path = os.path.join(
@@ -152,10 +154,11 @@ class EcoreGenerator(multigen.jinja.JinjaGenerator):
     module_path_map = {'ecore': 'pyecore.ecore'}
 
     def __init__(self, *, user_module=None, auto_register_package=False,
-                 with_dependencies=False, **kwargs):
+                 with_dependencies=False, textX=False, **kwargs):
         self.user_module = user_module
         self.auto_register_package = auto_register_package
         self.with_dependencies = with_dependencies
+        self.textX = textX
 
         self.tasks = [
             EcorePackageInitTask(formatter=multigen.formatter.format_autopep8),
@@ -296,7 +299,8 @@ class EcoreGenerator(multigen.jinja.JinjaGenerator):
     def create_global_context(self, **kwargs):
         return super().create_global_context(
             user_module=self.user_module,
-            auto_register_package=self.auto_register_package
+            auto_register_package=self.auto_register_package,
+            textX=self.textX
         )
 
     def create_environment(self, **kwargs):

--- a/pyecoregen/templates/module.py.tpl
+++ b/pyecoregen/templates/module.py.tpl
@@ -20,12 +20,49 @@ eClassifiers = {}
 getEClassifier = partial(Ecore.getEClassifier, searchspace=eClassifiers)
 
 {%- for c in element.eClassifiers if c is type(ecore.EEnum) -%}
+{% if loop.first and textX %}
+class EEnum(Ecore.EEnum):
+
+    def __init__(self, name=None, default_value=None, literals=None, **kwargs):
+        super().__init__(name, default_value, literals)
+        self.__dict__.update(kwargs)
+
+    @property
+    def value(self):
+        ''' returns the value of the attribute '''
+        for attr in [a for a in self.__dict__ if
+                     not a.startswith('__') and not
+                     a.startswith('_tx_')]:
+            obj = getattr(self, attr)
+            if obj and isinstance(obj, str):
+                return obj
+{% endif %}
 {{ modutil.generate_enum(c) }}
 {%- endfor %}
 {% for c in element.eClassifiers if c is type(ecore.EDataType) -%}
+{% if loop.first and textX %}
+class EDataType(Ecore.EDataType):
+
+    def __new__(cls, *args, **kwargs):
+        self = Ecore.EDataType.__new__(cls, *args, **kwargs)
+        self.__name__ = args[0]
+        return self
+
+{% endif %}
 {{ modutil.generate_edatatype(c) }}
 {%- endfor %}
 
 {%- for c in classes -%}
+{% if loop.first and textX %}
+class EObject(Ecore.EObject):
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        for key in kwargs:
+            if self.__dict__.get(key, False):
+                continue
+            setattr(self, key, kwargs[key])
+
+{% endif %}
 {{ modutil.generate_class(c) }}
 {%- endfor %}

--- a/pyecoregen/templates/module_utilities.tpl
+++ b/pyecoregen/templates/module_utilities.tpl
@@ -104,7 +104,7 @@ class Derived{{ d.name | capitalize }}(EDerivedCollection):
 
 {%- macro generate_class_init(c) %}
     def __init__(self{{ generate_class_init_args(c) }}, **kwargs):
-    {%- if not textX %}
+    {%- if not c.eSuperTypes and not textX %}
         if kwargs:
             raise AttributeError('unexpected arguments: {}'.format(kwargs))
     {%- endif %}

--- a/pyecoregen/templates/package.py.tpl
+++ b/pyecoregen/templates/package.py.tpl
@@ -34,6 +34,10 @@ from .. import {{ element.eSuperPackage.name }}
 from . import {{ sub.name }}
 {% endfor %}
 
+{% if textX %}
+classes = [{{ element.eClassifiers | map(attribute='name') | join(', ') }}]
+{% endif %}
+
 __all__ = [{{ element.eClassifiers | map(attribute='name') | map('pyquotesingle') | join(', ') }}]
 
 eSubpackages = [{{ element.eSubpackages | map(attribute='name') | join(', ') }}]


### PR DESCRIPTION
Changes:

- Add a cli option `--textX` to trigger textX compatible code generation.

- Override  `EEnum`, `EDataType`, and `EObject` to keep compatibility with textX.

- Ecore enums result in own classes.

- Disable kwargs check, because textX will always pass a parent parameter

- Disable None check for parameters

- Add `classes` variable

