### PR TITLE
Upgrade Python version and drop Python 3.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: python
 python:
-  - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
 install:
   - pip install --upgrade pip setuptools
   - pip install --upgrade pytest pytest-cov coveralls
@@ -18,4 +19,4 @@ deploy:
   distributions: "sdist bdist_wheel"
   on:
     tags: true
-    python: 3.6
+    python: 3.8

--- a/pyecoregen/ecore.py
+++ b/pyecoregen/ecore.py
@@ -227,6 +227,7 @@ class EcoreGenerator(multigen.jinja.JinjaGenerator):
     def filter_attrqualifiers(cls, value: ecore.EAttribute):
         qualifiers = dict(
             eType=value.eType.name,
+            unique=value.unique,
             derived=value.derived,
             changeable=value.changeable,
         )

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,8 @@ import sys
 from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
 
-if sys.version_info < (3, 3):
-    sys.exit('Sorry, Python < 3.3 is not supported')
+if sys.version_info < (3, 5):
+    sys.exit('Sorry, Python < 3.5 is not supported')
 
 
 class PyTest(TestCommand):

--- a/tests/input/E.ecore
+++ b/tests/input/E.ecore
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ecore:EPackage xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="e" nsURI="http://e/1.0" nsPrefix="e">
+  <eClassifiers xsi:type="ecore:EClass" name="E">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="values" unique="false" upperBound="-1" eType="ecore:EClass http://www.eclipse.org/emf/2002/Ecore#//EInt"/>
+  </eClassifiers>
+</ecore:EPackage>

--- a/tests/test_generated_library.py
+++ b/tests/test_generated_library.py
@@ -161,9 +161,9 @@ def test_static_init_bad_argument(generated_library):
         generated_library.Book(unknown=None)
 
 
-def test_static_init_dynamic_epackage_bad_value(generated_library):
-    with pytest.raises(Ecore.BadValueError):
-        DynamicEPackage(generated_library)
+def test_static_init_dynamic_epackage(generated_library):
+    package = DynamicEPackage(generated_library)
+    assert package.Book is not None
 
 
 def test_static_derived_attributes(generated_library):

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 import pytest
 
+from pyecore.resources import ResourceSet, URI
 from pyecore.ecore import EPackage, EClass, EReference, EEnum, EAttribute, EInt, EOperation, \
     EParameter, EString, EDataType, EAnnotation
 from pyecoregen.ecore import EcoreGenerator
@@ -405,3 +406,19 @@ def test_user_module_derived_collection(pygen_output_dir):
 
     with pytest.raises(AttributeError):
         c.other.append(d)
+
+
+@pytest.fixture(scope='module')
+def generated_E_metamodel(pygen_output_dir):
+    rset = ResourceSet()
+    resource = rset.get_resource(URI('input/E.ecore'))
+    library_model = resource.contents[0]
+    generator = EcoreGenerator()
+    generator.generate(library_model, pygen_output_dir)
+    return importlib.import_module('e')
+
+
+def test_cross_resource_packages(generated_E_metamodel):
+    instance = generated_E_metamodel.E(values=[1, 1, 2, 2, 3])
+    assert len(instance.values) == 5
+    assert instance.values == [1, 1, 2, 2, 3]


### PR DESCRIPTION
Python 3.4 is not supported anymore by lxml which is a dependency of PyEcore. PyEcore only supports now Python > 3.5. This PR upgrades supported version of Python in travis (for tests) and in the `setup.py`. This new version will be used as a basis for further PR.