### PR TITLE
Upgrade supported Python version and drop Python 3.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: python
 python:
-  - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
 install:
   - pip install --upgrade pip setuptools
   - pip install --upgrade pytest pytest-cov coveralls
@@ -18,4 +19,4 @@ deploy:
   distributions: "sdist bdist_wheel"
   on:
     tags: true
-    python: 3.6
+    python: 3.8

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,8 @@ import sys
 from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
 
-if sys.version_info < (3, 3):
-    sys.exit('Sorry, Python < 3.3 is not supported')
+if sys.version_info < (3, 5):
+    sys.exit('Sorry, Python < 3.5 is not supported')
 
 
 class PyTest(TestCommand):

--- a/tests/test_generated_library.py
+++ b/tests/test_generated_library.py
@@ -161,9 +161,9 @@ def test_static_init_bad_argument(generated_library):
         generated_library.Book(unknown=None)
 
 
-def test_static_init_dynamic_epackage_bad_value(generated_library):
-    with pytest.raises(Ecore.BadValueError):
-        DynamicEPackage(generated_library)
+def test_static_init_dynamic_epackage(generated_library):
+    package = DynamicEPackage(generated_library)
+    assert package.Book is not None
 
 
 def test_static_derived_attributes(generated_library):


### PR DESCRIPTION
Python 3.4 is not supported anymore by lxml which is a dependency of PyEcore. PyEcore only supports now Python > 3.5. This PR upgrades supported version of Python in travis (for tests) and in the setup.py. This new version will be used as a basis for further PR.