### PR TITLE
Feature/new sperelements

### DIFF
--- a/pyecoregen/templates/module_utilities.tpl
+++ b/pyecoregen/templates/module_utilities.tpl
@@ -88,10 +88,10 @@ class Derived{{ d.name | capitalize }}(EDerivedCollection):
 {#- -------------------------------------------------------------------------------------------- -#}
 
 {%- macro generate_class_init(c) %}
-    def __init__(self{{ generate_class_init_args(c) }}, **kwargs):
+    def __init__(self{{ generate_class_init_args(c) }}{% if c.eSuperTypes %}, **kwargs{% endif %}):
     {%- if not c.eSuperTypes %}
-        if kwargs:
-            raise AttributeError('unexpected arguments: {}'.format(kwargs))
+        # if kwargs:
+        #    raise AttributeError('unexpected arguments: {}'.format(kwargs))
     {%- endif %}
 
         super().__init__({% if c.eSuperTypes %}**kwargs{% endif %})

--- a/tests/test_generated_library.py
+++ b/tests/test_generated_library.py
@@ -161,9 +161,9 @@ def test_static_init_bad_argument(generated_library):
         generated_library.Book(unknown=None)
 
 
-def test_static_init_dynamic_epackage_bad_value(generated_library):
-    with pytest.raises(Ecore.BadValueError):
-        DynamicEPackage(generated_library)
+def test_static_init_dynamic_epackage(generated_library):
+    package = DynamicEPackage(generated_library)
+    assert package.Book is not None
 
 
 def test_static_derived_attributes(generated_library):

--- a/tests/test_generated_library.py
+++ b/tests/test_generated_library.py
@@ -157,7 +157,7 @@ def test_static_init_single_attribute_bad_type(generated_library):
 
 
 def test_static_init_bad_argument(generated_library):
-    with pytest.raises(AttributeError):
+    with pytest.raises(TypeError):
         generated_library.Book(unknown=None)
 
 


### PR DESCRIPTION
Currently, the keyword args which are not known by a metaclass raise an error.
This is an issue when, for some usages, multiple inheritance is used as the keyword could be consummed by another class from the inheritance tree.